### PR TITLE
Feat/virtual channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+## 1.0.0-beta.13
+
+__added__
+- `virtualPeerPubkeys` param on `UTEXOWalletNodeParams` / `IRLNNodeCreateParams` — host-key allowlist for inbound virtual channel acceptance. Pass `null` or `[]` for permissive mode (accept from any host); pass a list of pubkeys to restrict to specific hosts. Wired through the full native stack: `NativeRgb.ts` spec → `RLNBinding` → `RgbModule.kt` (Android) and `RgbSwiftHelper.swift` (iOS).
+- `docs/virtual-channels.md` — full reference for virtual channels: roles, open/payment/close flows, no-user-value predicate, allowlist semantics, and SDK usage examples.
+- Virtual Channels section in `Readme.md` with setup snippet, channel readiness poll, and payment example.
+
+---
+
+## 1.0.0-beta.12
+
+__added__
+- **VSS (Versioned Storage Service)** — encrypted remote node backup. New `UTEXOWalletNodeParams` fields: `vssUrl`, `vssAllowHttp`, `vssAllowEmptyRestore`. New method `vssClearFence(password)` to release the single-writer fence lock during restore on a new device.
+- **LSP integration** — `UtexoLsp` composed flow class (connect, wait for channel, receive/send asset, Lightning Address). Created via `wallet.createLsp(peer?)`. Raw HTTP client exposed as `lsp.http` (`UtexoLSPClient`). New types: `LspPeer`, `LspChannel`, `LspAssetConfig`. New `UTEXOWalletNodeParams` fields: `lspBaseUrl`, `lspBearerToken`.
+- **Async payments (APay)** — HODL-invoice–based offline receive. New methods: `apayNew(hostNodeId)`, `createHodlInvoice(params)`, `claimHodlInvoice(paymentHash, preimage)`, `cancelHodlInvoice(paymentHash)`, `listPaymentsRaw()`.
+- `enableVirtualChannelsV0` flag on `UTEXOWalletNodeParams` — enables the `trusted_no_broadcast` virtual channel mode on the node at startup.
+- Network defaults — `IRLNUnlockParams` fields are now optional with sensible per-network fallbacks (`indexerUrl`, `proxyEndpoint`, `bitcoindRpc*`). Defaults managed in `src/wallet/network-defaults.ts`.
+- `gossipRgsServerUrl` and `announceAlias` fields on `IRLNUnlockParams`.
+- `paymentHash` and `minFinalCltvExpiryDelta` params on `createLightningInvoice` / `rlnLnInvoice` for HODL invoice support.
+- `docs/lsp.md` and `docs/async-payments.md`.
+
+__changed__
+- Bumped RLN bindings to `v1.0.0-beta.12`.
+- Internal refactor: removed legacy `WalletManager` abstraction; `UTEXOWallet` is now the sole public wallet class.
+- `listUnspents` updated to reflect latest RLN response shape.
+- `@utexo/rgb-sdk-core` dependency updated.
+
+---
+
+## 1.0.0-beta.10
+
+__added__
+- **`UTEXOWallet`** — new high-level wallet class implementing both `IWalletManager` and `IUTEXOProtocol`, backed by an on-device RLN (RGB Lightning Node). Replaces the old rgb-lib-backed `UTEXOWallet`.
+- **`RLNManager` / `RLNBinding`** — native bridge layer exposing the full RLN node lifecycle (`rlnCreateNode`, `rlnShutdown`, `rlnDestroyNode`, all channel / payment / RGB operations) to TypeScript.
+- **`IRLNSigner` + two implementations** — `PasswordRLNSigner` (password-based init/unlock) and `NativeExternalRLNSigner` (BIP39 seed, no password stored in memory), with a shared `IRLNUnlockParams` connection type.
+- **Node lifecycle** — `init()` → `unlock()` → use → `shutdown()` / `reinit()` / `destroy()`. `reinit()` recreates the internal `RLNManager` so the same `UTEXOWallet` instance can be restarted after shutdown without hitting the "node already created" guard.
+- **iOS / Android native bridge** (`Rgb.mm` / `RgbSwiftHelper.swift` / `RgbModule.kt`) expanded with ~60 new RLN methods. `RlnNodeStore` handles per-node lifecycle including `SHUTDOWN → INITIALIZED` restart on both platforms.
+
+__changed__
+- Old rgb-lib-backed `UTEXOWallet` removed; `src/index.ts` updated accordingly.
+- README fully rewritten to document `UTEXOWallet`, both signers, lifecycle phases, method reference, and core workflows.
+
+---

--- a/Readme.md
+++ b/Readme.md
@@ -86,6 +86,7 @@ After shutdown, restart on the same instance with `await wallet.reinit(unlockPar
 - Open Lightning channels and send/receive BTC or RGB asset payments
 - LSP integration: receive RGB via Lightning, send RGB to on-chain recipients, Lightning Address — see [docs/lsp.md](./docs/lsp.md)
 - Async payments (APay): hash pool + Lightning Address via utexo-lsp — see [docs/async-payments.md](./docs/async-payments.md)
+- Virtual channels: instant-usable channels with no on-chain footprint via trusted `no-broadcast` mode — see [docs/virtual-channels.md](./docs/virtual-channels.md)
 - Issue, transfer, and manage RGB assets (NIA, CFA, IFA, UDA)
 - Manage UTXOs and BTC on-chain sends
 - Use a hardware-wallet–style **external signer** or a simple **password signer**
@@ -132,7 +133,8 @@ const wallet = new UTEXOWallet(
 | `ldkPeerListeningPort` | `number` | LDK peer-to-peer port |
 | `network` | `string` | Bitcoin network (`'utexo'`, `'regtest'`, `'testnet'`, `'mainnet'`, …) |
 | `maxMediaUploadSizeMb` | `number?` | Max media upload size in MB (default 20) |
-| `enableVirtualChannelsV0` | `boolean?` | Enable virtual channel support |
+| `enableVirtualChannelsV0` | `boolean?` | Enable virtual channel support (required on both host and client) |
+| `virtualPeerPubkeys` | `string[]?` | Host pubkeys allowed to open inbound virtual channels. `null`/`[]` = accept from anyone |
 | `vssUrl` | `string?` | VSS server URL for encrypted remote backup |
 | `vssAllowHttp` | `boolean?` | Allow plain HTTP VSS endpoint (default `false`) |
 | `vssAllowEmptyRestore` | `boolean?` | Allow restoring from VSS when no backup exists yet (default `false`) |
@@ -1013,6 +1015,7 @@ for (const p of payments) {
 |-----|-------------|
 | [docs/lsp.md](./docs/lsp.md) | Full LSP reference: `UtexoLsp`, `LspPeer`, all methods, examples |
 | [docs/async-payments.md](./docs/async-payments.md) | Async payment (APay) protocol, six-step flow diagrams, SDK usage |
+| [docs/virtual-channels.md](./docs/virtual-channels.md) | Virtual channels: trusted no-broadcast, host-key allowlist, `virtualPeerPubkeys`, SDK usage |
 
 ---
 

--- a/Readme.md
+++ b/Readme.md
@@ -750,6 +750,61 @@ try {
 
 ---
 
+## Virtual Channels
+
+Virtual channels are Lightning channels that become usable immediately — the funding UTXO is never broadcast to Bitcoin. The LSP opens a `trusted_no_broadcast` channel directly to the client wallet; no block confirmations required, no on-chain footprint.
+
+### Setup
+
+```typescript
+// Client wallet — enable virtual channels and optionally restrict to a specific LSP
+const wallet = new UTEXOWallet({
+  ...nodeParams,
+  enableVirtualChannelsV0: true,
+  virtualPeerPubkeys: ['02lspPubkey…'],  // omit or pass null/[] to accept from any host
+  lspBaseUrl: 'https://lsp-signet.utexo.com',
+}, signer);
+
+await wallet.init();
+await wallet.unlock(unlockParams);
+```
+
+### Receiving a virtual channel (client side)
+
+The LSP opens the channel — nothing extra needed on the client. Once `enableVirtualChannelsV0: true` is set and the LSP pubkey is in `virtualPeerPubkeys` (or the list is empty), the channel is accepted automatically.
+
+```typescript
+// Poll until the virtual channel is ready
+let ready = false;
+while (!ready) {
+  const channels = await wallet.listChannels();
+  ready = channels.some(
+    c => c.virtualOpenMode === 'trusted_no_broadcast' && c.ready && c.isUsable
+  );
+  if (!ready) await new Promise(r => setTimeout(r, 1000));
+}
+```
+
+### Payments over a virtual channel
+
+Virtual channels are transparent to the payment APIs — use the same `createLightningInvoice` / `payLightningInvoice` calls as for regular channels.
+
+```typescript
+// Receive
+const { lnInvoice } = await wallet.createLightningInvoice({
+  amountSats: 3_000,
+  expirySeconds: 900,
+  asset: { assetId: ASSET_ID, amount: 1 },
+});
+
+// Send
+const { txid: paymentHash } = await wallet.payLightningInvoice({ lnInvoice });
+```
+
+**Full reference → [docs/virtual-channels.md](./docs/virtual-channels.md)**
+
+---
+
 ## LSP Integration
 
 `utexo-lsp` bridges on-chain RGB assets with Lightning payments. The SDK exposes it through `UtexoLsp` — a composed flow class created from the wallet.

--- a/android/src/main/java/com/rgbsdkrn/RgbModule.kt
+++ b/android/src/main/java/com/rgbsdkrn/RgbModule.kt
@@ -72,6 +72,7 @@ class RgbModule(reactContext: ReactApplicationContext) :
     network: String,
     maxMediaUploadSizeMb: Double,
     enableVirtualChannelsV0: Boolean?,
+    virtualPeerPubkeys: ReadableArray?,
     vssUrl: String?,
     vssAllowHttp: Boolean,
     vssAllowEmptyRestore: Boolean,
@@ -82,6 +83,9 @@ class RgbModule(reactContext: ReactApplicationContext) :
     coroutineScope.launch(Dispatchers.IO) {
       try {
         android.util.Log.d("RgbModule", "[rlnCreateNode] network=$network vssUrl=$vssUrl lspBaseUrl=$lspBaseUrl daemonPort=$daemonListeningPort ldkPort=$ldkPeerListeningPort")
+        val peerPubkeysList: List<String>? = virtualPeerPubkeys?.let { arr ->
+          (0 until arr.size()).map { arr.getString(it) ?: "" }.filter { it.isNotEmpty() }
+        }
         val initRequest = SdkInitRequest(
           storageDirPath = storageDirPath,
           daemonListeningPort = daemonListeningPort.toInt().toUShort(),
@@ -89,7 +93,7 @@ class RgbModule(reactContext: ReactApplicationContext) :
           network = network,
           maxMediaUploadSizeMb = maxMediaUploadSizeMb.toInt().toUShort(),
           enableVirtualChannelsV0 = enableVirtualChannelsV0,
-          virtualPeerPubkeys = null,
+          virtualPeerPubkeys = peerPubkeysList,
           lspBaseUrl = lspBaseUrl,
           lspBearerToken = lspBearerToken,
           vssUrl = vssUrl,

--- a/docs/virtual-channels.md
+++ b/docs/virtual-channels.md
@@ -1,0 +1,184 @@
+# Virtual Channels (`trusted_no_broadcast`)
+
+Virtual channels are trusted Lightning channels where the funding UTXO is **never broadcast** to Bitcoin — the channel becomes usable immediately. RGB-backed virtual channels use a trusted no-broadcast funding path with an RGB proxy for consignment delivery. `/closechannel` is allowed only when the host can prove no user value remains in the channel.
+
+---
+
+## Roles
+
+- **Host (LSP)** — opens virtual channels, constructs the virtual funding outpoint, registers it with LDK, enforces policy, and executes cleanup via `closeChannel`.
+- **Client (wallet)** — accepts the inbound channel via trusted zero-conf and uses existing Lightning payment APIs over the channel.
+
+Both host and client run RLN with vendored LDK handling the channel state machine, acceptance, and the trusted no-broadcast primitives on each side.
+
+---
+
+## Open channel flow
+
+The host calls `POST /openchannel` with `virtual_open_mode=trusted_no_broadcast` (requires `--enable-virtual-channels-v0` startup flag). The request is rejected if `public=true` or if a draft or session already exists for the same peer.
+
+The client accepts via trusted zero-conf. Since the funding UTXO is never confirmed on-chain there is no real SCID — a **scid-alias** (a locally assigned fake identifier both peers agree on) is the only channel identifier that exists. Client B encodes this alias in invoice route hints so payments can be routed through the host.
+
+In `FundingGenerationReady` the host constructs the virtual funding outpoint. For RGB-backed channels this is the transaction ID of an unbroadcast RGB funding PSBT. The RGB consignment is posted to the proxy; the client fetches and validates it automatically via LDK's channel funding handler. The host then registers the outpoint via `unsafe_manual_funding_transaction_generated` — **no broadcast**. The channel becomes usable immediately.
+
+---
+
+## Payment routing
+
+Two clients connected to the same host can pay each other through a hub-and-spoke topology: `Client A → Host → Client B`. Client B creates a BOLT11 invoice with a private route hint encoding `Host → Client B` via the inbound SCID alias. Client A pays — first hop to Host, then Host forwards over the private virtual channel to Client B. The host must have `accept_forwards_to_priv_channels` enabled.
+
+---
+
+## Close channel
+
+`closeChannel` is constrained for virtual channels:
+
+- `force=true` is **always rejected** — force-close would attempt to broadcast a commitment transaction whose funding UTXO was never on-chain.
+- A cooperative close is allowed only when the **no-user-value predicate** passes (all conditions in order):
+  1. No in-flight HTLCs in current LDK channel state
+  2. No channel-scoped pending RGB markers on disk
+  3. Counterparty (client) commitment BTC balance floor is exactly `0`
+  4. For RGB channels: both final and pending RGB state records exist and agree on `contract_id`, `schema`, `local_rgb_amount`, and `remote_rgb_amount == 0`
+
+If any condition fails, `closeChannel` is rejected with a `CannotCloseChannel` error.
+
+---
+
+## Host-key allowlist (`virtualPeerPubkeys`)
+
+The allowlist lives on the **inbound (receiving) side** — the client checks it when an incoming virtual channel open arrives.
+
+| Client `virtualPeerPubkeys` | Inbound virtual open from any host |
+|---|---|
+| `null` / `[]` (empty) | **Accepted** — permissive, no restriction |
+| `['02lspPubkey…']` | Accepted **only** from that pubkey; all others rejected |
+| `['02wrongKey…']` (wrong key) | Rejected — channel never becomes `ready && is_usable` |
+
+The **host** always starts with an empty allowlist. This is correct: the host only opens channels outbound and never receives inbound virtual channels.
+
+When the client's allowlist does not include the opener's pubkey, the channel handshake completes (HTTP 200 on the host side) but neither node's channel ever reaches `ready && is_usable`. Both sides see the channel pending indefinitely — the security guarantee tested by `virtual_open_non_allowlisted_host_does_not_become_operational`.
+
+### One virtual channel per peer pair
+
+The host enforces a single active virtual channel per `(host, client)` peer pair. A second `openChannel` call while one already exists returns HTTP 400 with `"already exists for this peer pair"`. Concurrent duplicate requests are rejected atomically.
+
+---
+
+## Validation rules (enforced by RLN)
+
+| Rule | Error |
+|---|---|
+| `--enable-virtual-channels-v0` must be set on the initiating node | `"trusted virtual channels v0 are disabled"` |
+| `virtual_open_mode` must be `"trusted_no_broadcast"` | `"unknown virtual_open_mode: <value>"` |
+| `public` must be `false` | `"virtual channels requires public=false"` |
+
+---
+
+## SDK integration
+
+Both flags are passed at **node creation time** in `UTEXOWalletNodeParams` (i.e. the `UTEXOWallet` constructor). They cannot be changed after the node is started.
+
+### Constructor params
+
+```typescript
+import { UTEXOWallet } from '@utexo/rgb-sdk-rn';
+
+// Host / LSP node — opens virtual channels to clients
+const hostWallet = new UTEXOWallet({
+  storageDirPath,
+  daemonListeningPort,
+  ldkPeerListeningPort,
+  network: 'regtest',
+  enableVirtualChannelsV0: true,
+  virtualPeerPubkeys: null,        // host never receives inbound virtual opens
+  lspBaseUrl: 'http://…',
+}, signer);
+
+// Client — accepts virtual channels from one specific LSP only
+const clientWallet = new UTEXOWallet({
+  storageDirPath,
+  daemonListeningPort,
+  ldkPeerListeningPort,
+  network: 'regtest',
+  enableVirtualChannelsV0: true,
+  virtualPeerPubkeys: ['02lspPubkey…'],
+  lspBaseUrl: 'http://…',
+}, signer);
+
+// Client — no allowlist, accepts inbound from any host
+const openClientWallet = new UTEXOWallet({
+  storageDirPath,
+  daemonListeningPort,
+  ldkPeerListeningPort,
+  network: 'regtest',
+  enableVirtualChannelsV0: true,
+  virtualPeerPubkeys: null,        // or [] — node starts fine, accepts from anyone
+  lspBaseUrl: 'http://…',
+}, signer);
+```
+
+`virtualPeerPubkeys: null` and `virtualPeerPubkeys: []` are equivalent — both map to an empty Rust `Vec<PublicKey>` which means "accept from all". The node starts successfully either way.
+
+### Opening a virtual channel (host / LSP side)
+
+```typescript
+const channel = await wallet.openChannel({
+  peerPubkeyAndOptAddr: `${clientPubkey}@host:port`,
+  capacitySat: 100_000,
+  pushMsat: 10_000_000,
+  assetId: 'rgb:…',
+  assetAmount: 200,
+  publicChannel: false,                       // required — virtual channels must be private
+  withAnchors: true,
+  virtualOpenMode: 'trusted_no_broadcast',
+});
+// channel.virtualOpenMode === 'trusted_no_broadcast'
+// channel.ready === true, channel.isUsable === true (no blocks to wait for)
+```
+
+### Checking the channel
+
+```typescript
+const channels = await wallet.listChannels();
+const virtual = channels.find(
+  c => c.virtualOpenMode === 'trusted_no_broadcast' && c.ready && c.isUsable
+);
+```
+
+---
+
+## Channel lifecycle data
+
+### `VirtualChannelSession` status
+
+| Status | Meaning |
+|---|---|
+| `Active` | Channel is operational |
+| `AbandonPending` | Close in progress |
+| `Abandoned` | Channel abandoned without broadcast — terminal |
+
+### Channel in `listChannels`
+
+Virtual channels appear in `listChannels` with a `virtualOpenMode` field. The `fundingTxid` is the transaction ID portion of the virtual funding outpoint — it was never broadcast.
+
+---
+
+## Relevant Rust tests
+
+| Test | What it verifies |
+|---|---|
+| `virtual_open_non_allowlisted_host_does_not_become_operational` | Client with wrong pubkey in allowlist never gets an operational channel |
+| `virtual_open_rejects_duplicate_peer_pair_concurrently_and_sequentially` | Exactly one virtual channel per peer pair; concurrent + sequential duplicates rejected |
+| `virtual_open_rejects_invalid_requests` | `enable_virtual_channels_v0=false`, unknown mode, `public=true` all return 400 |
+| `virtual_trusted_no_broadcast_survives_funding_timeout_and_routes_btc_and_rgb_payments` | Channel stays live past 2017 blocks; BTC + RGB payments succeed; multi-client routing works |
+| `virtual_hodl_invoice_cancel_clears_pending_artifacts_and_allows_close` | Cancelling a HODL invoice over a virtual channel clears all pending RGB artifacts |
+| `virtual_close_succeeds_after_client_returns_full_btc_and_rgb` | Host can only close once counterparty returns full balance |
+| `virtual_reconciliation_ignores_orphan_pending_rgb_entries` | Orphan KVStore RGB entries don't block payments |
+
+Source: [`src/test/virtual_channels.rs`](https://github.com/UTEXO-Protocol/rgb-lightning-node/blob/dev/src/test/virtual_channels.rs)
+
+---
+
+## Demo
+
+The demo app includes a virtual channel flow at [`flows/async-pay/`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo) — it shows wallet construction with `enableVirtualChannelsV0: true`, LSP channel setup, and RGB payments over the virtual channel.

--- a/docs/virtual-channels.md
+++ b/docs/virtual-channels.md
@@ -163,22 +163,6 @@ Virtual channels appear in `listChannels` with a `virtualOpenMode` field. The `f
 
 ---
 
-## Relevant Rust tests
-
-| Test | What it verifies |
-|---|---|
-| `virtual_open_non_allowlisted_host_does_not_become_operational` | Client with wrong pubkey in allowlist never gets an operational channel |
-| `virtual_open_rejects_duplicate_peer_pair_concurrently_and_sequentially` | Exactly one virtual channel per peer pair; concurrent + sequential duplicates rejected |
-| `virtual_open_rejects_invalid_requests` | `enable_virtual_channels_v0=false`, unknown mode, `public=true` all return 400 |
-| `virtual_trusted_no_broadcast_survives_funding_timeout_and_routes_btc_and_rgb_payments` | Channel stays live past 2017 blocks; BTC + RGB payments succeed; multi-client routing works |
-| `virtual_hodl_invoice_cancel_clears_pending_artifacts_and_allows_close` | Cancelling a HODL invoice over a virtual channel clears all pending RGB artifacts |
-| `virtual_close_succeeds_after_client_returns_full_btc_and_rgb` | Host can only close once counterparty returns full balance |
-| `virtual_reconciliation_ignores_orphan_pending_rgb_entries` | Orphan KVStore RGB entries don't block payments |
-
-Source: [`src/test/virtual_channels.rs`](https://github.com/UTEXO-Protocol/rgb-lightning-node/blob/dev/src/test/virtual_channels.rs)
-
----
-
 ## Demo
 
 The demo app includes a virtual channel flow at [`flows/async-pay/`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo) — it shows wallet construction with `enableVirtualChannelsV0: true`, LSP channel setup, and RGB payments over the virtual channel.

--- a/ios/Rgb.mm
+++ b/ios/Rgb.mm
@@ -44,6 +44,7 @@ ldkPeerListeningPort:(double)ldkPeerListeningPort
               network:(NSString *)network
   maxMediaUploadSizeMb:(double)maxMediaUploadSizeMb
 enableVirtualChannelsV0:(NSNumber *)enableVirtualChannelsV0
+  virtualPeerPubkeys:(NSArray *)virtualPeerPubkeys
                vssUrl:(NSString *)vssUrl
          vssAllowHttp:(BOOL)vssAllowHttp
   vssAllowEmptyRestore:(BOOL)vssAllowEmptyRestore
@@ -60,6 +61,7 @@ enableVirtualChannelsV0:(NSNumber *)enableVirtualChannelsV0
             @"network": network ?: @"",
             @"maxMediaUploadSizeMb": @(maxMediaUploadSizeMb),
             @"enableVirtualChannelsV0": enableVirtualChannelsV0 ?: [NSNull null],
+            @"virtualPeerPubkeys": virtualPeerPubkeys ?: [NSNull null],
             @"vssUrl": vssUrl ?: [NSNull null],
             @"vssAllowHttp": @(vssAllowHttp),
             @"vssAllowEmptyRestore": @(vssAllowEmptyRestore),

--- a/ios/RgbSwiftHelper.swift
+++ b/ios/RgbSwiftHelper.swift
@@ -39,6 +39,7 @@ public class RgbSwiftHelper: NSObject {
             let maxMediaUploadSizeMb = request["maxMediaUploadSizeMb"] as? NSNumber else {
         return ["error": "Invalid rlnCreateNode request"] as NSDictionary
       }
+      let virtualPeerPubkeys: [String]? = (request["virtualPeerPubkeys"] as? [String]).flatMap { $0.isEmpty ? nil : $0 }
       let initReq = SdkInitRequest(
         storageDirPath: storageDirPath,
         daemonListeningPort: UInt16(truncating: daemonListeningPort),
@@ -46,7 +47,7 @@ public class RgbSwiftHelper: NSObject {
         network: network,
         maxMediaUploadSizeMb: UInt16(truncating: maxMediaUploadSizeMb),
         enableVirtualChannelsV0: request["enableVirtualChannelsV0"] as? Bool,
-        virtualPeerPubkeys: nil,
+        virtualPeerPubkeys: virtualPeerPubkeys,
         lspBaseUrl: request["lspBaseUrl"] as? String,
         lspBearerToken: request["lspBearerToken"] as? String,
         vssUrl: request["vssUrl"] as? String,

--- a/src/binding/IRLN.ts
+++ b/src/binding/IRLN.ts
@@ -37,6 +37,7 @@ export interface IRLNNodeCreateParams {
   network: string;
   maxMediaUploadSizeMb: number;
   enableVirtualChannelsV0?: boolean | null;
+  virtualPeerPubkeys?: string[] | null;
   vssUrl?: string | null;
   vssAllowHttp?: boolean;
   vssAllowEmptyRestore?: boolean;

--- a/src/binding/NativeRgb.ts
+++ b/src/binding/NativeRgb.ts
@@ -9,6 +9,7 @@ export interface Spec extends TurboModule {
     network: string,
     maxMediaUploadSizeMb: number,
     enableVirtualChannelsV0: boolean | null,
+    virtualPeerPubkeys: string[] | null,
     vssUrl: string | null,
     vssAllowHttp: boolean,
     vssAllowEmptyRestore: boolean,

--- a/src/binding/RLNBinding.ts
+++ b/src/binding/RLNBinding.ts
@@ -89,6 +89,7 @@ export class RLNBinding implements IRLN {
         params.network,
         params.maxMediaUploadSizeMb,
         params.enableVirtualChannelsV0 ?? null,
+        params.virtualPeerPubkeys ?? null,
         params.vssUrl ?? null,
         params.vssAllowHttp ?? false,
         params.vssAllowEmptyRestore ?? false,

--- a/src/wallet/utexo-wallet.ts
+++ b/src/wallet/utexo-wallet.ts
@@ -124,6 +124,7 @@ export interface UTEXOWalletNodeParams {
   network: string;
   maxMediaUploadSizeMb?: number;
   enableVirtualChannelsV0?: boolean;
+  virtualPeerPubkeys?: string[] | null;
   vssUrl?: string | null;
   vssAllowHttp?: boolean;
   vssAllowEmptyRestore?: boolean;
@@ -1051,6 +1052,7 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
       network: toNativeNetwork(this.params.network as BitcoinNetwork),
       maxMediaUploadSizeMb: this.params.maxMediaUploadSizeMb ?? 20,
       enableVirtualChannelsV0: this.params.enableVirtualChannelsV0 ?? null,
+      virtualPeerPubkeys: this.params.virtualPeerPubkeys ?? null,
       vssUrl: this.params.vssUrl ?? null,
       vssAllowHttp: this.params.vssAllowHttp ?? false,
       vssAllowEmptyRestore: this.params.vssAllowEmptyRestore ?? false,


### PR DESCRIPTION
This PR adds virtual channel host-key allowlist support across the SDK stack.

Changes:
- Wired `virtualPeerPubkeys` through Android / iOS / JS bindings:
  - `NativeRgb.ts` spec
  - `RLNBinding`
  - `RgbModule.kt`
  - `RgbSwiftHelper.swift`
- Both Android and iOS now pass the allowlist to `rlnCreateNode`
- Added `virtualPeerPubkeys?: string[] | null` to `UTEXOWalletNodeParams`

Allowlist behavior:
- Pass `null` or `[]` to use permissive mode and accept inbound virtual channels from any host
- Pass a list of pubkeys to restrict trusted virtual channel hosts

Docs:
- Added `docs/virtual-channels.md` with:
  - roles
  - open / payment / close flows
  - no-user-value predicate
  - allowlist behavior
  - SDK usage examples