### PR TITLE
Feat/lsp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.0.0-beta.14
+
+__added__
+- Plain BTC Lightning invoices — `createLightningInvoice` now accepts requests without `asset` (`RlnCreateLightningInvoiceRequestModel`).
+- `listChannels` returns previously missing fields on both platforms: `status`, `nextOutboundHtlcLimitMsat`, `nextOutboundHtlcMinimumMsat`, `peerAlias`, `shortChannelId`, `virtualOpenMode` (host-side only).
+- Canonical enum unions: `RlnTransactionType`, `RlnChannelStatus`.
+
+__fixed__
+- iOS/Android enum case divergence — enum-as-string results normalized at the `RLNBinding` boundary (`rlnInvoiceStatus`, `rlnSendPayment`, `rlnKeysend`, channel `status`, `transactionType`). Fixes settlement polling stuck on `Pending` on iOS.
+- `listTransactions` — transaction types no longer collapse to `'User'`; native values map correctly onto core `TransactionType`.
+- `UtexoLsp.receiveAsset` — sends the LN invoice's remaining lifetime as `durationSeconds`; full expiry failed utexo-lsp's expiry-match validation (HTTP 400) on slow invoice creation.
+- `UtexoLSPClient.onchainSend` — response fields were always `undefined` (snake_case wire keys); now mapped explicitly.
+- iOS build error in `Rgb.mm` — `bitcoindRpcPort` nullability conflict with the codegen protocol.
+
+__changed__
+- `UtexoLSPClient` (`getInfo`, `lightningReceive`, `onchainSend`) — strict snake_case wire parsing, defensive fallback chains removed.
+
+---
+
 ## 1.0.0-beta.13
 
 __added__

--- a/Readme.md
+++ b/Readme.md
@@ -304,7 +304,7 @@ await wallet.destroy();
 | `getLspConfig()` | Return `{ baseUrl, bearerToken }` this node was initialized with |
 | `apayNew(hostNodeId)` | Register a hash pool with the host LSP node |
 | `createHodlInvoice(params)` | Create a HODL invoice tied to a specific payment hash |
-| `claimHodlInvoice(paymentHash, preimage)` | Claim an inbound HODL payment by revealing the preimage |
+| `claimHodlInvoice(paymentHash, preimage)` | Reveal preimage to claim an inbound HODL payment |
 | `cancelHodlInvoice(paymentHash)` | Cancel a HODL invoice |
 | `listPaymentsRaw()` | Return all payments including `InboundHodl` with preimage |
 
@@ -855,8 +855,8 @@ const { lnInvoice, rgbInvoice } = await lsp.receiveAsset({
 });
 
 // 3. Share rgbInvoice with the on-chain sender
-// 4. Wait for settlement
-await lsp.awaitReceiveSettlement(lnInvoice, {
+// 4. Wait for settlement ('settled' | 'timed_out')
+const outcome = await lsp.awaitReceiveSettlement(lnInvoice, {
   onProgress: (s) => console.log('status:', s),
 });
 ```
@@ -872,14 +872,17 @@ const { sendResult } = await lsp.sendAsset({
 });
 ```
 
-### Lightning Address (offline receive)
+### Lightning Address (APay / offline receive)
 
 ```typescript
+await lsp.connect();
+await lsp.waitForChannel(ASSET_ID, { … });
+
 const { address } = await lsp.enableLightningAddress();
 // → 'username@lsp-signet.utexo.com'
 
-// On every unlock — claim payments received while offline
-const claimed = await lsp.claimPendingPayments();
+// While app is foreground: lsp.connect() periodically so LSP outbox can reach you.
+// Settlement is automatic — see docs/async-payments.md.
 ```
 
 ### Pay a Lightning Address
@@ -898,25 +901,25 @@ await lsp.payAddress({
 
 #### Async payments (APay)
 
-Async payments let a recipient receive RGB Lightning payments while their wallet is offline. The payer sends a BOLT11 invoice; the LSP holds the HTLC until the recipient comes online and claims it.
+Async payments let a recipient receive RGB Lightning while **offline at payment time**. The payer pays a HODL BOLT11 via LNURL; the LSP holds the HTLC until the recipient is **reachable over P2P**, then the **LSP outbox** settles automatically.
 
 **Flow overview:**
 
 ```
 Recipient                    LSP (Host RLN)              Sender
     │                              │                        │
-    │── apayNew(hostNodeId) ──────►│ registers hash pool    │
-    │◄─ ApayNewResponse ───────────│ creates Lightning Addr  │
-    │                              │                        │
-    │   (goes offline)             │                        │
+    │── enableLightningAddress ───►│ hash pool + LN Address │
+    │── lsp.connect() (online)     │                        │
     │                              │◄── payLightningInvoice ─│
     │                              │    HTLC held            │
     │                              │                        │
-    │   (comes back online)        │                        │
-    │── listPaymentsRaw() ─────────┤ finds InboundHodl      │
-    │── claimHodlInvoice() ───────►│ reveals preimage        │
-    │                              │──── settles HTLC ──────►│
+    │   (lsp.connect when online)  │ outbox: pay merchant   │
+    │                              │ auto-claim → preimage  │
+    │                              │──── settles payer HTLC ►│
+    │◄── RGB delivered ────────────│                        │
 ```
+
+Full reference → **[docs/async-payments.md](./docs/async-payments.md)**
 
 ##### `apayNew(hostNodeId)`
 
@@ -954,7 +957,7 @@ The `hashes` array contains the payment hashes sent to the LSP. The LSP uses the
 
 ##### `createHodlInvoice(params)`
 
-Create a BOLT11 HODL invoice tied to a specific `paymentHash`. The invoice will not auto-settle when paid — the HTLC is held at the payer's node until `claimHodlInvoice` is called with the matching preimage.
+Create a BOLT11 HODL invoice tied to a specific `paymentHash`. Use when your app issues the invoice directly (APay Lightning Address checkout uses LNURL → Host `/lninvoice` instead).
 
 ```typescript
 const invoice = await wallet.createHodlInvoice({
@@ -986,7 +989,7 @@ const invoice = await wallet.createHodlInvoice({
 
 ##### `claimHodlInvoice(paymentHash, preimage)`
 
-Reveal the preimage for an inbound HODL payment. The node verifies `sha256(preimage) === paymentHash`, then settles the held HTLC — releasing the funds to the recipient and completing the payment from the sender's perspective.
+Reveal the preimage for an inbound HODL payment created with `createHodlInvoice`.
 
 ```typescript
 const result = await wallet.claimHodlInvoice(
@@ -996,7 +999,7 @@ const result = await wallet.claimHodlInvoice(
 // result.changed — true if the invoice state was updated
 ```
 
-Call this after `listPaymentsRaw()` finds a payment with `status === 'Claimable'`.
+Call after `listPaymentsRaw()` finds a payment with `status === 'Claimable'`.
 
 ---
 
@@ -1013,7 +1016,7 @@ const result = await wallet.cancelHodlInvoice(paymentHash);
 
 ##### `listPaymentsRaw()`
 
-Return all payments the node knows about, including held inbound HODL payments. Use this after coming online to find payments that arrived while offline.
+Return all payments the node knows about. Monitor inbound `INBOUND_HODL` → `Succeeded` for APay receive; filter `Claimable` + call `claimHodlInvoice` for HODL invoices you issued.
 
 ```typescript
 const payments = await wallet.listPaymentsRaw();
@@ -1039,30 +1042,50 @@ const claimable = payments.filter(
 
 ---
 
-##### Full async payment example
+##### Full APay example
+
+See **[docs/async-payments.md](./docs/async-payments.md)** and the demo [`useApayFlow.ts`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo/blob/main/screens/apay/useApayFlow.ts).
 
 ```typescript
-// ── Recipient: register once after unlock ────────────────────────────────────
-const pool = await wallet.apayNew(lspPeerPubkey);
-console.log(`Hash pool registered — ${pool.hashes.length} hashes issued`);
-console.log(`Unused: ${pool.unusedHashes}  Order: ${pool.orderId}`);
+// ── Recipient ────────────────────────────────────────────────────────────────
+await lsp.connect();
+await lsp.waitForChannel(ASSET_ID, { … });
+const { address } = await lsp.enableLightningAddress();
 
-// ── Recipient: come online and claim ────────────────────────────────────────
-await wallet.syncWallet();
-const payments = await wallet.listPaymentsRaw();
+// ── Sender ───────────────────────────────────────────────────────────────────
+await senderLsp.connect();
+await senderLsp.waitForChannel(ASSET_ID, { … });
+await senderLsp.waitForOutboundLiquidity(3_000_000, { … });
 
-for (const p of payments) {
-  if (p.paymentType !== 'InboundHodl' || p.status !== 'Claimable') continue;
-  if (!p.preimage) continue;
+const { pr } = await senderLsp.http.resolveAddress(username, 3_000_000, ASSET_ID, 1);
+const { txid: paymentHash, status } = await senderWallet.payLightningInvoice({
+  lnInvoice: pr, assetId: ASSET_ID, assetAmount: 1,
+});
 
-  const result = await wallet.claimHodlInvoice(p.paymentHash, p.preimage);
-  if (result.changed) {
-    console.log(`Claimed payment: ${p.amtMsat} msat  hash=${p.paymentHash}`);
-  }
+// ── Settlement (recipient online: lsp.connect()) ─────────────────────────────
+await lsp.connect();
+// Poll until sender Settled + recipient inbound SUCCEEDED
+let settled = false;
+while (!settled) {
+  await senderWallet.syncWallet();
+  await wallet.syncWallet();
+  const sendSt = await senderWallet.getLightningSendRequest(paymentHash!);
+  const inbound = (await wallet.listPaymentsRaw())
+    .find(p => p.paymentHash === paymentHash);
+  if (sendSt === 'Settled' && inbound?.status === 'Succeeded') settled = true;
 }
 ```
 
-> **Note:** `UtexoLsp.claimPendingPayments()` encapsulates the filter + loop above. Use it when you don't need per-payment result inspection.
+##### Claim pending HODL payments
+
+```typescript
+for (const p of await wallet.listPaymentsRaw()) {
+  if (p.paymentType !== 'InboundHodl' || p.status !== 'Claimable') continue;
+  if (!p.preimage) continue;
+  await wallet.claimHodlInvoice(p.paymentHash, p.preimage);
+}
+// Or: await lsp.claimPendingPayments();
+```
 
 ## Further reading
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation("com.utexo:rgb-lightning-node-android:0.5.1-beta.1")
+  implementation("com.utexo:rgb-lightning-node-android:0.5.2-beta.1")
   // UniFFI-generated RLN Kotlin bindings require JNA. Use Android AAR artifact
   // explicitly to avoid Gradle resolving both .aar and .jar variants.
   implementation "net.java.dev.jna:jna:5.17.0@aar"

--- a/android/src/main/java/com/rgbsdkrn/RgbModule.kt
+++ b/android/src/main/java/com/rgbsdkrn/RgbModule.kt
@@ -523,17 +523,23 @@ class RgbModule(reactContext: ReactApplicationContext) :
           val map = Arguments.createMap()
           map.putString("channelId", ch.channelId)
           map.putString("peerPubkey", ch.peerPubkey)
+          map.putString("status", ch.status.name)
           map.putBoolean("ready", ch.ready)
           map.putBoolean("isUsable", ch.isUsable)
           map.putDouble("capacitySat", ch.capacitySat.toDouble())
           map.putDouble("localBalanceSat", ch.localBalanceSat.toDouble())
           map.putDouble("outboundBalanceMsat", ch.outboundBalanceMsat.toDouble())
           map.putDouble("inboundBalanceMsat", ch.inboundBalanceMsat.toDouble())
+          map.putDouble("nextOutboundHtlcLimitMsat", ch.nextOutboundHtlcLimitMsat.toDouble())
+          map.putDouble("nextOutboundHtlcMinimumMsat", ch.nextOutboundHtlcMinimumMsat.toDouble())
           map.putBoolean("public", ch.public)
           ch.fundingTxid?.let { map.putString("fundingTxid", it) }
+          ch.peerAlias?.let { map.putString("peerAlias", it) }
+          ch.shortChannelId?.let { map.putDouble("shortChannelId", it.toDouble()) }
           ch.assetId?.let { map.putString("assetId", it) }
           ch.assetLocalAmount?.let { map.putDouble("assetLocalAmount", it.toDouble()) }
           ch.assetRemoteAmount?.let { map.putDouble("assetRemoteAmount", it.toDouble()) }
+          ch.virtualOpenMode?.let { map.putString("virtualOpenMode", it) }
           arr.pushMap(map)
         }
         withContext(Dispatchers.Main) { promise.resolve(arr) }

--- a/docs/async-payments.md
+++ b/docs/async-payments.md
@@ -4,16 +4,20 @@ Async payments let a recipient receive Lightning while **offline at payment time
 
 **Protocol spec:** [Async Payments — RGB Lightning Node & Utexo LSP](https://hackmd.io/@xalkan/async-payments)
 
+**Working demo:** [rgb-sdk-rn-demo `screens/apay/useApayFlow.ts`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo/blob/main/screens/apay/useApayFlow.ts)
+
 ---
 
 ## Roles
 
 | Role | Component | Your app calls it? |
 |------|-----------|-------------------|
-| Recipient | Recipient RLN on device | Yes — register pool, claim HODL |
+| Recipient | Recipient RLN on device | Yes — register pool, **`lsp.connect()` while online** |
 | Host | LSP's RLN node | No — P2P + HTTP to utexo-lsp |
 | Orchestrator | utexo-lsp | Partial — LNURL + discovery HTTP only |
-| Payer | Sender RLN on device | Yes — LNURL + pay invoice |
+| Payer | Sender RLN on device | Yes — LNURL + pay + poll send status |
+
+> **Important:** APay settlement is **automatic**. When the LSP outbox pays the merchant's outbound invoice, the recipient node auto-claims (`async_payment_recipient: true`). Your app calls `lsp.connect()` while online and polls for `Succeeded`. See [Lightning Address vs HODL invoice](#lightning-address-vs-hodl-invoice) below.
 
 ---
 
@@ -21,12 +25,12 @@ Async payments let a recipient receive Lightning while **offline at payment time
 
 ```mermaid
 flowchart TD
-  S1["① Register hash pool<br/><b>Recipient app</b><br/>wallet.apayNew(hostPubkey)<br/>lsp.http.getLightningAddressByPubkey(pubkey)"]
-  S2["② Payer fetches invoice<br/><b>Sender app</b><br/>GET /.well-known/lnurlp/{username}<br/>GET callback?amount=… → HODL BOLT11"]
+  S1["① Register hash pool<br/><b>Recipient app</b><br/>lsp.connect()<br/>lsp.enableLightningAddress()"]
+  S2["② Payer fetches invoice<br/><b>Sender app</b><br/>lsp.http.resolveAddress(…)<br/>→ HODL BOLT11 from Host /lninvoice"]
   S3["③ Payer pays<br/><b>Sender app</b><br/>wallet.payLightningInvoice(pr)<br/>HTLC held at Host — not settled yet"]
-  S4["④ Request outbound invoice<br/><b>Automatic</b> — utexo-lsp outbox + Host RLN<br/>async_order.request_invoice → Recipient RLN"]
-  S5["⑤ Outbound pay + recipient claim<br/><b>Recipient app</b> when online<br/>listPaymentsRaw → InboundHodl Claimable<br/>claimHodlInvoice(hash, preimage)"]
-  S6["⑥ Claim inbound<br/><b>Automatic</b> — utexo-lsp outbox + Host RLN<br/>claimhodlinvoice with revealed preimage"]
+  S4["④ Request outbound invoice<br/><b>Automatic</b> — utexo-lsp outbox + Host RLN<br/>P2P apay/request_invoice → Recipient RLN"]
+  S5["⑤ Outbound pay + auto-claim<br/><b>Automatic</b> — Host pays Recipient<br/>Recipient RLN auto-claims (no app claim)"]
+  S6["⑥ Claim inbound<br/><b>Automatic</b> — utexo-lsp outbox + Host RLN<br/>settles payer HTLC with preimage"]
 
   S1 --> S2 --> S3 --> S4 --> S5 --> S6
   S6 -.->|pool empty| S1
@@ -34,23 +38,23 @@ flowchart TD
   style S1 fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
   style S2 fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
   style S3 fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
-  style S5 fill:#1e3a5f,stroke:#60a5fa,color:#e2e8f0
   style S4 fill:#1a2e1a,stroke:#4ade80,color:#e2e8f0
+  style S5 fill:#1a2e1a,stroke:#4ade80,color:#e2e8f0
   style S6 fill:#1a2e1a,stroke:#4ade80,color:#e2e8f0
 ```
 
 | Step | What happens | Who drives it | SDK call |
 |------|-------------|---------------|----------|
-| **①** | Hash batch stored; Lightning Address minted for `peer_pubkey` | **Recipient app** | `wallet.apayNew(lspPeerPubkey)` then `lsp.http.getLightningAddressByPubkey(pubkey)` |
-| **②** | Next `hash_index` reserved; inbound HODL BOLT11 issued | **Sender app** | `lsp.http.resolveAddress(username, amtMsat, assetId?, assetAmount?)` |
-| **③** | Payer pays BOLT11; inbound HTLC held | **Sender app** | `wallet.payLightningInvoice({ lnInvoice, assetId?, assetAmount? })` |
-| **④** | LSP notified claimable; outbox asks Recipient for outbound HODL invoice | **Host + utexo-lsp** | Recipient RLN must be online to answer P2P |
-| **⑤** | Host pays outbound invoice; Recipient claims → preimage revealed | **Recipient app** | `wallet.listPaymentsRaw()` → `claimHodlInvoice(hash, preimage)` |
-| **⑥** | Host claims inbound HTLC with preimage; payment complete | **Host + utexo-lsp** | — |
+| **①** | Hash batch stored; Lightning Address minted | **Recipient app** | `lsp.connect()` → `lsp.enableLightningAddress()` |
+| **②** | Hash slot reserved; inbound HODL BOLT11 from Host | **Sender app** | `lsp.http.resolveAddress(username, amtMsat, assetId?, assetAmount?)` |
+| **③** | Payer pays BOLT11; inbound HTLC held at Host | **Sender app** | `lsp.waitForOutboundLiquidity(…)` then `wallet.payLightningInvoice(…)` |
+| **④** | Outbox asks Recipient for outbound invoice over P2P | **Host + utexo-lsp** | Recipient must be reachable — **`lsp.connect()`** |
+| **⑤** | Host pays outbound invoice; Recipient **auto-claims** | **Host + Recipient RLN** | App: optional `listPaymentsRaw()` → `INBOUND_HODL/SUCCEEDED` |
+| **⑥** | Host settles payer HTLC with preimage | **Host + utexo-lsp** | App: poll `getLightningSendRequest(hash)` → `Settled` |
 
-**Blue steps (①②③⑤)** — your app. **Green steps (④⑥)** — LSP cron/outbox; you just keep the node online for ④.
+**Blue steps (①②③)** — your app. **Green steps (④⑤⑥)** — LSP outbox; recipient app keeps **`lsp.connect()`** alive when online.
 
-When `unusedHashes` hits zero, utexo-lsp marks the order exhausted — call `apayNew` again to refill. `refillBatchSize` in the `ApayNewResponse` tells you how many hashes to include in each refill batch.
+When `unusedHashes` hits zero, call `apayNew` / `enableLightningAddress` again to refill.
 
 ---
 
@@ -67,189 +71,188 @@ sequenceDiagram
   participant L as utexo-lsp
 
   Note over RB,L: ① Register
-  RB->>RR: apayNew(lspPeerPubkey)
+  RB->>RR: lsp.connect()
+  RB->>RR: apayNew / enableLightningAddress
   RR--)H: async_order.new (P2P)
   H->>L: POST /internal/async_order/new
-  L-->>RR: order_id, pool stats
   RB->>L: GET /lightning_address/by_pubkey/{pubkey}
   L-->>RB: username, domain
 
-  Note over SA,L: ②③ Pay
+  Note over SA,L: ②③ Pay (LNURL callback — no P2P to Recipient yet)
   SA->>L: LNURL /.well-known/lnurlp/{username}
-  L->>H: request inbound HODL invoice
-  H--)RR: async_order.request_invoice
-  RR-->>H: BOLT11 (hodl)
+  L->>H: POST /lninvoice (hodl, reserved hash)
+  H-->>L: inbound HODL BOLT11
   L-->>SA: pr
   SA->>SR: payLightningInvoice(pr)
   SR->>H: HTLC (held)
 
-  Note over H,L: ④⑤⑥ Settle
+  Note over H,L: ④⑤⑥ Settle (Recipient must be online for ④)
   H->>L: POST /internal/async_order/claimable
-  L->>H: outbox: outbound invoice + pay
-  H--)RR: async_order.request_invoice
-  RR-->>H: outbound BOLT11
+  L->>H: outbox: request outbound invoice
+  H--)RR: apay/request_invoice (P2P)
+  RR-->>H: outbound BOLT11 (async_payment_recipient)
   H->>RR: pay outbound
-  RB->>RR: claimHodlInvoice (⑤)
+  Note over RR: auto-claim — no app claimHodlInvoice
   RR-->>H: preimage
-  L->>H: outbox: claimhodlinvoice (⑥)
+  L->>H: outbox: claim inbound HTLC (⑥)
+  SR->>H: payer HTLC Settled
 ```
 
 ---
 
 ## SDK usage
 
-The recipient wallet must be constructed with `enableVirtualChannelsV0: true`. This is required for the LSP's 0-conf virtual channel offer — without it, the LSP's `FundingGenerationReady` event fails with `ChannelFundingType::Virtual requires a negotiated 0-conf channel`.
+### Wallet + LSP setup
+
+**Utexo / signet (production):**
 
 ```typescript
-import { UTEXOWallet, type LspPeer } from '@utexo/rgb-sdk-rn';
-
 const wallet = new UTEXOWallet({
   ...nodeParams,
-  lspBaseUrl:              'https://lsp-signet.utexo.com',
-  lspBearerToken:          'bearer-token',
-  enableVirtualChannelsV0: true,   // required for virtual 0-conf LSP channels
+  lspBaseUrl:     'https://lsp-signet.utexo.com',
+  lspBearerToken: 'bearer-token',
 }, signer);
 
 await wallet.init();
 await wallet.unlock(unlockParams);
 
-const LSP_PEER: LspPeer = {
-  baseUrl:    'https://lsp-signet.utexo.com',
-  peerPubkey: lspPeerPubkey,
-  peerHost:   'lsp-signet.utexo.com',
-  peerPort:   9735,
-};
-const lsp = await wallet.createLsp(LSP_PEER);
+const lsp = await wallet.createLsp();  // discovers pubkey/host from lspBaseUrl + GET /get_info
 ```
 
-### ① Register + get Lightning Address
+**Regtest local demo** (virtual 0-conf channels — not required on signet):
 
 ```typescript
-// Connect to LSP peer first
+const wallet = new UTEXOWallet({
+  ...nodeParams,
+  lspBaseUrl:              'http://127.0.0.1:8080',
+  enableVirtualChannelsV0: true,
+  virtualPeerPubkeys:      [lspPeerPubkey],  // fetch once from GET /get_info
+}, signer);
+
+const lsp = await wallet.createLsp(undefined, 9737);  // regtest LDK port ≠ default 9735
+```
+
+Explicit `LspPeer` + `createLsp(LSP_PEER)` is still valid when you cannot set `lspBaseUrl` on the wallet (e.g. Android emulator host override).
+
+### ① Recipient — register + Lightning Address
+
+Both sides need an RGB channel first: `lsp.connect()` → `lsp.waitForChannel(assetId, { … })`.
+
+```typescript
 await lsp.connect();
 
-// Option A — one-shot helper (recommended): apayNew + getLightningAddressByPubkey
+// Recommended: apayNew + getLightningAddressByPubkey in one call
 const { address } = await lsp.enableLightningAddress();
-console.log(`Lightning Address: ${address}`);  // e.g. alice@lsp-signet.utexo.com
+console.log(`Lightning Address: ${address}`);
 
-// Option B — manual: register pool separately, then fetch address
-const pool = await wallet.apayNew(lspPeerPubkey);
-console.log(`${pool.hashes.length} hashes issued, ${pool.unusedHashes} unused`);
-const addr = await lsp.http.getLightningAddressByPubkey(walletPubkey);
-console.log(`Lightning Address: ${addr.username}@${addr.domain}`);
+// Keep calling lsp.connect() while the app is foreground / expecting payments
+// so the LSP outbox can reach the node over P2P when a payer pays.
 ```
 
-`apayNew` returns an `ApayNewResponse`:
-
-| Field | Description |
-|-------|-------------|
-| `orderId` | Persistent order ID — store it to track pool exhaustion |
-| `unusedHashes` | How many hashes remain available for incoming payments |
-| `refillBatchSize` | How many hashes to send when calling `apayNew` again to refill |
-| `hashes` | `Array<{ hashIndex, paymentHash }>` — the hashes sent to the Host |
-
-When `unusedHashes` approaches zero, call `apayNew` again with a new batch to refill the pool.
-
-### ③ Sender pays (on the sender's device)
+Manual alternative:
 
 ```typescript
-// Step 1 — resolve the Lightning Address to a HODL BOLT11
-// lsp.http.resolveAddress handles Android emulator host rewriting internally
+const pool = await wallet.apayNew(lspPubkey);
+const addr = await lsp.http.getLightningAddressByPubkey(walletPubkey);
+```
+
+### ②③ Sender — LNURL pay
+
+```typescript
+await senderLsp.connect();
+await senderLsp.waitForChannel(ASSET_ID, { … });
+await senderLsp.waitForOutboundLiquidity(3_000_000, { … });
+
 const { pr } = await senderLsp.http.resolveAddress(
-  username,        // e.g. 'alice'
-  3_000_000,       // amtMsat
-  ASSET_ID,        // RGB asset ID (pass undefined for sats-only)
-  1,               // assetAmount (pass undefined for sats-only)
+  username, 3_000_000, ASSET_ID, 1,
 );
 
-// Step 2 — pay the HODL invoice; LSP holds the HTLC until recipient claims
 const payResult = await senderWallet.payLightningInvoice({
   lnInvoice:   pr,
-  assetId:     ASSET_ID,    // optional — required for RGB asset payments
-  assetAmount: 1,           // optional
+  assetId:     ASSET_ID,
+  assetAmount: 1,
 });
-
-// Or use the one-shot helper if you don't need to inspect the invoice:
-const { invoice, sendResult } = await senderLsp.payAddress({
-  address: 'alice@lsp-signet.utexo.com',
-  amtMsat: 3_000_000,
-  asset:   { assetId: ASSET_ID, assetAmount: 1 },  // omit for sats-only
-});
+// payResult.status is usually Pending — HTLC held at Host
+const paymentHash = payResult.txid;
 ```
 
-### ⑤ Recipient comes online and claims
+`lsp.payAddress({ address, amtMsat, asset })` resolves + pays in one call but **does not wait** for APay LSP outbox settlement.
+
+### ④⑤⑥ Settlement — poll until complete
+
+**Recipient** (when app resumes / comes online):
 
 ```typescript
+await lsp.connect();
 await wallet.syncWallet();
-const payments = await wallet.listPaymentsRaw();
 
-// Manual loop
-for (const p of payments) {
+const payments = await wallet.listPaymentsRaw();
+// APay inbound: INBOUND_HODL → SUCCEEDED (auto-claim, no claimHodlInvoice)
+```
+
+**Sender:**
+
+```typescript
+const status = await senderWallet.getLightningSendRequest(paymentHash);
+// Poll until status === 'Settled' (or 'Failed')
+```
+
+**Success checks (RGB):**
+
+- Sender: `getLightningSendRequest` → `Settled`
+- Recipient: inbound `INBOUND_HODL/SUCCEEDED`, or `getAssetBalance(assetId).offchainOutbound` increased
+- Use **`offchainOutbound`** (local spendable RGB), not `offchainInbound`, for receive confirmation
+
+---
+
+## Lightning Address vs HODL invoice
+
+| | **Lightning Address (APay)** | **HODL invoice you create** |
+|---|------------------------------|-------------------------------|
+| Register | `enableLightningAddress()` / `apayNew` | `createHodlInvoice({ paymentHash, … })` |
+| Payer path | LNURL → Host HODL BOLT11 | Pay BOLT11 directly |
+| Recipient claim | **Automatic** (RLN auto-claim) | **`claimHodlInvoice(hash, preimage)`** |
+| Helper | — | `lsp.claimPendingPayments()` |
+
+```typescript
+// After createHodlInvoice — claim when status is Claimable
+for (const p of await wallet.listPaymentsRaw()) {
   if (p.paymentType !== 'InboundHodl' || p.status !== 'Claimable') continue;
   if (!p.preimage) continue;
-
-  const result = await wallet.claimHodlInvoice(p.paymentHash, p.preimage);
-  if (result.changed) console.log(`Claimed: ${p.amtMsat} msat`);
+  await wallet.claimHodlInvoice(p.paymentHash, p.preimage);
 }
-
-// Or use the one-shot helper — returns ClaimResult[] for each attempted claim:
-const claimed = await lsp.claimPendingPayments();
-// [{ paymentHash: '...', claimed: true }, { paymentHash: '...', claimed: false, error: '...' }]
 ```
-
-`claimPendingPayments` filters for `Claimable` and `Claiming` statuses, attempts each claim, and never throws — failures are captured as `{ claimed: false, error }` entries.
-
-### Cancelling a HODL invoice
-
-If you want to reject a held payment (e.g. invoice expired or payment should not be accepted), cancel it before the LSP times out:
-
-```typescript
-const result = await wallet.cancelHodlInvoice(paymentHash);
-// result.changed — true if the invoice state changed
-```
-
-Cancelling fails the inbound HTLC back to the sender. Use this when an `InboundHodl` payment arrives that you decide not to claim.
 
 ---
 
 ## API reference
 
-| Method | Step | Returns | Description |
-|--------|------|---------|-------------|
-| `wallet.apayNew(hostNodeId)` | ① | `ApayNewResponse` | Register hash pool with Host RLN |
-| `lsp.http.getLightningAddressByPubkey(pubkey)` | ① | `{ username, domain }` | Resolve Lightning Address after registration |
-| `lsp.enableLightningAddress()` | ① | `LightningAddressInfo` | `apayNew` + `getLightningAddressByPubkey` in one call |
-| `lsp.http.resolveAddress(username, amtMsat, assetId?, assetAmount?)` | ② | `{ pr: string }` | Fetch HODL BOLT11 from LSP LNURL callback |
-| `lsp.payAddress({ address, amtMsat, asset? })` | ②③ | `{ invoice, sendResult }` | LNURL resolution + pay in one call |
-| `wallet.payLightningInvoice({ lnInvoice, assetId?, assetAmount? })` | ③ | `LightningSendRequest` | Pay HODL BOLT11 directly |
-| `wallet.listPaymentsRaw()` | ⑤ | `RlnPayment[]` | Find `InboundHodl` + `Claimable` + `preimage` |
-| `wallet.claimHodlInvoice(paymentHash, preimage)` | ⑤ | `{ changed: boolean }` | Reveal preimage; LSP settles inbound HTLC |
-| `wallet.cancelHodlInvoice(paymentHash)` | ⑤ | `{ changed: boolean }` | Fail inbound HTLC back to sender |
-| `lsp.claimPendingPayments()` | ⑤ | `ClaimResult[]` | Filter + claim all claimable in one call |
+| Method | Step | Description |
+|--------|------|-------------|
+| `lsp.connect()` | ①④ | Lightning P2P to Host — call before register and when coming online |
+| `lsp.waitForChannel(assetId)` | ①③ | Wait for usable RGB channel |
+| `lsp.enableLightningAddress()` | ① | `apayNew` + `getLightningAddressByPubkey` |
+| `lsp.http.resolveAddress(…)` | ② | LNURL callback → HODL BOLT11 |
+| `lsp.waitForOutboundLiquidity(msat)` | ③ | Confirm sender can route before pay |
+| `wallet.payLightningInvoice(…)` | ③ | Pay HODL invoice |
+| `wallet.getLightningSendRequest(hash)` | ⑥ | Poll sender until `Settled` |
+| `wallet.listPaymentsRaw()` | ⑤ | Monitor recipient inbound (`SUCCEEDED`) |
+| `wallet.getAssetBalance(assetId)` | ⑤ | Confirm RGB received (`offchainOutbound` ↑) |
+| `wallet.createHodlInvoice(…)` | — | Issue a HODL invoice you control (pairs with claim below) |
+| `wallet.claimHodlInvoice(…)` | — | Reveal preimage for a `createHodlInvoice` payment |
+| `lsp.claimPendingPayments()` | — | Claim all pending HODL payments after unlock |
 
-**Not called from the app:** `POST /internal/async_order/*` — Host RLN uses those internally with utexo-lsp.
+**Not called from the app:** `POST /internal/async_order/*` — Host RLN uses those with utexo-lsp.
 
 ### `RlnPayment` fields (from `listPaymentsRaw`)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `paymentHash` | `string` | Payment identifier |
-| `paymentType` | `'Outbound' \| 'InboundAutoClaim' \| 'InboundHodl'` | `InboundHodl` = held |
-| `status` | `'Pending' \| 'Claimable' \| 'Claiming' \| 'Succeeded' \| 'Cancelled' \| 'Failed'` | |
-| `preimage` | `string?` | Present when `status === 'Claimable'` — pass to `claimHodlInvoice` |
-| `amtMsat` | `number?` | Amount in millisatoshis |
-| `assetId` | `string?` | RGB asset ID if RGB payment |
-| `assetAmount` | `number?` | RGB asset amount |
-| `payeePubkey` | `string` | Counterparty pubkey |
-| `createdAt` | `number` | Unix timestamp (seconds) |
-
-### `ClaimResult` (from `claimPendingPayments`)
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `paymentHash` | `string` | Payment hash that was attempted |
-| `claimed` | `boolean` | `true` if `claimHodlInvoice` succeeded |
-| `error` | `string?` | Error message if `claimed` is `false` |
+| `paymentType` | `'Outbound' \| 'InboundAutoClaim' \| 'InboundHodl'` | APay receive: `INBOUND_HODL` |
+| `status` | `'Pending' \| 'Claimable' \| 'Claiming' \| 'Succeeded' \| …'` | APay complete: `Succeeded` |
+| `preimage` | `string?` | On `Claimable` HODL invoices — pass to `claimHodlInvoice` |
+| `assetId` / `assetAmount` | optional | RGB leg |
 
 ---
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -126,17 +126,18 @@ Internally:
 Poll `wallet.getLightningReceiveRequest(lnInvoice)` until it reaches a terminal state.
 
 ```typescript
-await lsp.awaitReceiveSettlement(lnInvoice, {
+const outcome = await lsp.awaitReceiveSettlement(lnInvoice, {
   timeoutMs:      60_000,
   pollIntervalMs:  2_000,
   onProgress: (status) => setUiStatus(status),
 });
-// Returns 'Succeeded' or throws LspSettlementError({ step: 'ln_invoice', status })
+// outcome: 'settled' | 'timed_out'
+// throws LspSettlementError({ step: 'ln_invoice', status }) on Failed | Expired
 ```
 
-Status progression: `'Pending'` → `'Succeeded'` | `'Failed'` | `'Expired'`
+Wallet status progression: `'Pending'` → `'Succeeded'` | `'Failed'` | `'Expired'`
 
-On timeout the method returns `'Succeeded'` without throwing — a timeout is not a confirmed failure, the LSP cron may still be processing.
+Return value: `'settled'` when Succeeded is confirmed; `'timed_out'` when timeoutMs elapses without a terminal status (LSP cron may still be processing — not a confirmed failure).
 
 ---
 
@@ -213,7 +214,7 @@ The `lspBaseUrl` **and** `lspBearerToken` on the wallet node params must be set 
 
 ### `claimPendingPayments()`
 
-Find all `CLAIMABLE` / `CLAIMING` inbound HODL payments and claim each one by revealing the preimage. Call after every `unlock()` when the wallet comes back online.
+Find all `CLAIMABLE` / `CLAIMING` inbound HODL payments and call `claimHodlInvoice` on each. Use for invoices created with `createHodlInvoice` — e.g. after `unlock()` when the wallet comes back online.
 
 ```typescript
 const results = await lsp.claimPendingPayments();
@@ -320,28 +321,50 @@ const { lnInvoice } = await recipientWallet.createLightningInvoice({
 await wallet.payLightningInvoice({ lnInvoice });
 ```
 
-### Enable Lightning Address (offline receive / APay)
+### APay — Lightning Address (offline receive)
 
 ```typescript
-// wallet node must be constructed with lspBaseUrl + lspBearerToken
 const wallet = new UTEXOWallet({
   ...nodeParams,
-  lspBaseUrl:      'https://lsp-signet.utexo.com',
-  lspBearerToken:  'bearer-token',
+  lspBaseUrl:     'https://lsp-signet.utexo.com',
+  lspBearerToken: 'bearer-token',
 }, signer);
 await wallet.init();
 await wallet.unlock(unlockParams);
 
-const lsp = await wallet.createLsp(LSP_PEER);
+const lsp = await wallet.createLsp();  // or createLsp(undefined, 9737) on regtest
 
-// Register once after first unlock
+await lsp.connect();
+await lsp.waitForChannel(ASSET_ID, { onProgress: (m) => console.log(m) });
+
 const { address } = await lsp.enableLightningAddress();
-console.log('Your Lightning Address:', address);
-// → 'excited-mountain-1234@lsp-signet.utexo.com'
+console.log('Lightning Address:', address);
 
-// On every subsequent unlock, claim any payments received while offline
+// When app is foreground / expecting payment: lsp.connect() so LSP outbox can reach you.
+// Settlement is automatic — poll listPaymentsRaw() or sender getLightningSendRequest until Succeeded.
+```
+
+Sender side:
+
+```typescript
+await senderLsp.connect();
+await senderLsp.waitForChannel(ASSET_ID, { … });
+await senderLsp.waitForOutboundLiquidity(3_000_000, { … });
+
+const { pr } = await senderLsp.http.resolveAddress(username, 3_000_000, ASSET_ID, 1);
+const pay = await senderWallet.payLightningInvoice({ lnInvoice: pr, assetId: ASSET_ID, assetAmount: 1 });
+
+// Poll until Settled
+const status = await senderWallet.getLightningSendRequest(pay.txid!);
+```
+
+Full flow → [async-payments.md](./async-payments.md). Demo → [rgb-sdk-rn-demo `useApayFlow.ts`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo/blob/main/screens/apay/useApayFlow.ts).
+
+### Claim pending HODL payments
+
+```typescript
 const claimed = await lsp.claimPendingPayments();
-console.log(`Claimed ${claimed.filter(c => c.claimed).length} payments`);
+console.log(`Claimed ${claimed.filter(c => c.claimed).length} HODL payments`);
 ```
 
 ---

--- a/docs/virtual-channels.md
+++ b/docs/virtual-channels.md
@@ -165,4 +165,4 @@ Virtual channels appear in `listChannels` with a `virtualOpenMode` field. The `f
 
 ## Demo
 
-The demo app includes a virtual channel flow at [`flows/async-pay/`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo) — it shows wallet construction with `enableVirtualChannelsV0: true`, LSP channel setup, and RGB payments over the virtual channel.
+The demo app includes APay flows at [`screens/apay/useApayFlow.ts`](https://github.com/UTEXO-Protocol/rgb-sdk-rn-demo/blob/main/screens/apay/useApayFlow.ts) — wallet construction with `enableVirtualChannelsV0: true`, LSP channel setup, LNURL checkout, and LSP outbox settlement.

--- a/ios/RGBLightningNode.swift
+++ b/ios/RGBLightningNode.swift
@@ -4364,10 +4364,11 @@ public struct Payment {
     public var updatedAt: UInt64
     public var payeePubkey: PublicKey
     public var preimage: String?
+    public var descriptionHash: String?
 
     /// Default memberwise initializers are never public by default, so we
     /// declare one manually.
-    public init(amtMsat: UInt64?, assetAmount: UInt64?, assetId: ContractId?, paymentHash: PaymentHash, paymentType: PaymentType, status: HtlcStatus, createdAt: UInt64, updatedAt: UInt64, payeePubkey: PublicKey, preimage: String?) {
+    public init(amtMsat: UInt64?, assetAmount: UInt64?, assetId: ContractId?, paymentHash: PaymentHash, paymentType: PaymentType, status: HtlcStatus, createdAt: UInt64, updatedAt: UInt64, payeePubkey: PublicKey, preimage: String?, descriptionHash: String?) {
         self.amtMsat = amtMsat
         self.assetAmount = assetAmount
         self.assetId = assetId
@@ -4378,6 +4379,7 @@ public struct Payment {
         self.updatedAt = updatedAt
         self.payeePubkey = payeePubkey
         self.preimage = preimage
+        self.descriptionHash = descriptionHash
     }
 }
 
@@ -4413,6 +4415,9 @@ extension Payment: Equatable, Hashable {
         if lhs.preimage != rhs.preimage {
             return false
         }
+        if lhs.descriptionHash != rhs.descriptionHash {
+            return false
+        }
         return true
     }
 
@@ -4427,6 +4432,7 @@ extension Payment: Equatable, Hashable {
         hasher.combine(updatedAt)
         hasher.combine(payeePubkey)
         hasher.combine(preimage)
+        hasher.combine(descriptionHash)
     }
 }
 
@@ -4446,7 +4452,8 @@ public struct FfiConverterTypePayment: FfiConverterRustBuffer {
                 createdAt: FfiConverterUInt64.read(from: &buf),
                 updatedAt: FfiConverterUInt64.read(from: &buf),
                 payeePubkey: FfiConverterTypePublicKey.read(from: &buf),
-                preimage: FfiConverterOptionString.read(from: &buf)
+                preimage: FfiConverterOptionString.read(from: &buf),
+                descriptionHash: FfiConverterOptionString.read(from: &buf)
             )
     }
 
@@ -4461,6 +4468,7 @@ public struct FfiConverterTypePayment: FfiConverterRustBuffer {
         FfiConverterUInt64.write(value.updatedAt, into: &buf)
         FfiConverterTypePublicKey.write(value.payeePubkey, into: &buf)
         FfiConverterOptionString.write(value.preimage, into: &buf)
+        FfiConverterOptionString.write(value.descriptionHash, into: &buf)
     }
 }
 

--- a/ios/Rgb.mm
+++ b/ios/Rgb.mm
@@ -128,7 +128,7 @@ enableVirtualChannelsV0:(NSNumber *)enableVirtualChannelsV0
   bitcoindRpcUsername:(NSString * _Nullable)bitcoindRpcUsername
   bitcoindRpcPassword:(NSString * _Nullable)bitcoindRpcPassword
       bitcoindRpcHost:(NSString * _Nullable)bitcoindRpcHost
-      bitcoindRpcPort:(NSNumber * _Nullable)bitcoindRpcPort
+      bitcoindRpcPort:(NSNumber *)bitcoindRpcPort
             indexerUrl:(NSString *)indexerUrl
          proxyEndpoint:(NSString *)proxyEndpoint
      announceAddresses:(NSArray<NSString *> *)announceAddresses
@@ -939,7 +939,7 @@ minFinalCltvExpiryDelta:(NSNumber *)minFinalCltvExpiryDelta
                           bitcoindRpcUsername:(NSString * _Nullable)bitcoindRpcUsername
                           bitcoindRpcPassword:(NSString * _Nullable)bitcoindRpcPassword
                               bitcoindRpcHost:(NSString * _Nullable)bitcoindRpcHost
-                              bitcoindRpcPort:(NSNumber * _Nullable)bitcoindRpcPort
+                              bitcoindRpcPort:(NSNumber *)bitcoindRpcPort
                                    indexerUrl:(NSString *)indexerUrl
                                 proxyEndpoint:(NSString *)proxyEndpoint
                             announceAddresses:(NSArray<NSString *> *)announceAddresses

--- a/ios/RgbSwiftHelper.swift
+++ b/ios/RgbSwiftHelper.swift
@@ -232,17 +232,23 @@ public class RgbSwiftHelper: NSObject {
         [
           "channelId": c.channelId,
           "peerPubkey": c.peerPubkey,
+          "status": "\(c.status)",
           "ready": c.ready,
           "isUsable": c.isUsable,
           "capacitySat": NSNumber(value: c.capacitySat),
           "localBalanceSat": NSNumber(value: c.localBalanceSat),
           "outboundBalanceMsat": NSNumber(value: c.outboundBalanceMsat),
           "inboundBalanceMsat": NSNumber(value: c.inboundBalanceMsat),
+          "nextOutboundHtlcLimitMsat": NSNumber(value: c.nextOutboundHtlcLimitMsat),
+          "nextOutboundHtlcMinimumMsat": NSNumber(value: c.nextOutboundHtlcMinimumMsat),
           "public": c.public,
           "fundingTxid": c.fundingTxid as Any,
+          "peerAlias": c.peerAlias as Any,
+          "shortChannelId": c.shortChannelId.map { NSNumber(value: $0) } as Any,
           "assetId": c.assetId as Any,
           "assetLocalAmount": c.assetLocalAmount.map { NSNumber(value: $0) } as Any,
           "assetRemoteAmount": c.assetRemoteAmount.map { NSNumber(value: $0) } as Any,
+          "virtualOpenMode": c.virtualOpenMode as Any,
         ] as NSDictionary
       }
       return ["channels": channels] as NSDictionary

--- a/scripts/download-rln-bindings.js
+++ b/scripts/download-rln-bindings.js
@@ -7,7 +7,7 @@ const { execSync } = require('child_process');
 // or used from a local zip in src/bindings/ if present.
 // Android AAR is resolved from Maven Central by Gradle — no download needed here.
 
-const VERSION = '0.5.1-beta.1';
+const VERSION = '0.5.2-beta.1';
 const BASE_URL = `https://github.com/UTEXO-Protocol/rgb-lightning-node/releases/download/v${VERSION}`;
 
 const ROOT = path.join(__dirname, '..');

--- a/src/binding/RLNBinding.ts
+++ b/src/binding/RLNBinding.ts
@@ -68,6 +68,16 @@ function normalizeBtcBalance(raw: any): RlnBtcBalance {
   };
 }
 
+// Android (Kotlin) serializes uniffi enums as SCREAMING_SNAKE ("RGB_SEND"),
+// iOS (Swift) interpolates the case name as lowerCamel ("rgbSend") — convert
+// both to canonical SCREAMING_SNAKE so the TS unions hold on every platform.
+function canonicalEnum(v: unknown): string | undefined {
+  if (v == null) return undefined;
+  const s = String(v);
+  if (/^[A-Z0-9_]+$/.test(s)) return s; // already canonical (Android)
+  return s.replace(/([a-z0-9])([A-Z])/g, '$1_$2').toUpperCase();
+}
+
 export class RLNBinding implements IRLN {
   private nodeOperationQueue: Promise<void> = Promise.resolve();
   private rlnNodeId: number | null = null;
@@ -340,9 +350,13 @@ export class RLNBinding implements IRLN {
   // ── Channels ────────────────────────────────────────────────────────────────
 
   async rlnListChannels(): Promise<RlnChannel[]> {
-    return this.withNodeOperation((nodeId) =>
+    const raw = (await this.withNodeOperation((nodeId) =>
       Rgb.rlnListChannels(nodeId)
-    ) as Promise<RlnChannel[]>;
+    )) as RlnChannel[];
+    return raw.map((c) => ({
+      ...c,
+      status: canonicalEnum((c as any).status) as RlnChannel['status'],
+    }));
   }
 
   async rlnOpenChannel(request: {
@@ -675,9 +689,15 @@ export class RLNBinding implements IRLN {
   }
 
   async rlnListTransactions(skipSync: boolean): Promise<RlnTransaction[]> {
-    return this.withNodeOperation((nodeId) =>
+    const raw = (await this.withNodeOperation((nodeId) =>
       Rgb.rlnListTransactions(nodeId, skipSync)
-    ) as Promise<RlnTransaction[]>;
+    )) as RlnTransaction[];
+    return raw.map((t) => ({
+      ...t,
+      transactionType: canonicalEnum(
+        (t as any).transactionType
+      ) as RlnTransaction['transactionType'],
+    }));
   }
 
   async rlnListTransfers(assetId: string): Promise<RlnTransfer[]> {

--- a/src/binding/RLNBinding.ts
+++ b/src/binding/RLNBinding.ts
@@ -413,7 +413,10 @@ export class RLNBinding implements IRLN {
       Rgb.rlnInvoiceStatus(nodeId, invoice)
     );
     const status = (raw as any)?.value ?? raw;
-    return status as RlnInvoiceStatus;
+    // Android (Kotlin) serializes the uniffi enum as "SUCCEEDED" while iOS
+    // (Swift) interpolates the case name as "succeeded" — normalize here so
+    // every status consumer sees the UPPERCASE contract of RlnInvoiceStatus.
+    return String(status).toUpperCase() as RlnInvoiceStatus;
   }
 
   async rlnLnInvoice(
@@ -480,9 +483,16 @@ export class RLNBinding implements IRLN {
     assetId: string | null,
     assetAmount: number | null
   ): Promise<RlnSendPaymentResponse> {
-    return this.withNodeOperation((nodeId) =>
+    const raw = (await this.withNodeOperation((nodeId) =>
       Rgb.rlnSendPayment(nodeId, invoice, amtMsat, assetId, assetAmount)
-    ) as Promise<RlnSendPaymentResponse>;
+    )) as RlnSendPaymentResponse;
+    // Android (Kotlin) serializes HtlcStatus as "PENDING" while iOS (Swift)
+    // interpolates the case name as "pending" — normalize to the UPPERCASE
+    // contract of RlnPaymentStatus.
+    return {
+      ...raw,
+      status: String(raw.status).toUpperCase() as RlnSendPaymentResponse['status'],
+    };
   }
 
   async rlnKeysend(
@@ -491,9 +501,14 @@ export class RLNBinding implements IRLN {
     assetId: string | null,
     assetAmount: number | null
   ): Promise<RlnKeysendResponse> {
-    return this.withNodeOperation((nodeId) =>
+    const raw = (await this.withNodeOperation((nodeId) =>
       Rgb.rlnKeysend(nodeId, destPubkey, amtMsat, assetId, assetAmount)
-    ) as Promise<RlnKeysendResponse>;
+    )) as RlnKeysendResponse;
+    // Same Android/iOS HtlcStatus case divergence as rlnSendPayment.
+    return {
+      ...raw,
+      status: String(raw.status).toUpperCase() as RlnKeysendResponse['status'],
+    };
   }
 
   // ── On-chain wallet ──────────────────────────────────────────────────────────

--- a/src/binding/rln-types.ts
+++ b/src/binding/rln-types.ts
@@ -73,9 +73,13 @@ export interface RlnPeer {
 
 // ── Channels ──────────────────────────────────────────────────────────────────
 
+/** Canonical SCREAMING_SNAKE — normalized at the RLNBinding boundary. */
+export type RlnChannelStatus = 'OPENING' | 'OPENED' | 'CLOSING';
+
 export interface RlnChannel {
   channelId: string;
   peerPubkey: string;
+  status?: RlnChannelStatus;
   ready: boolean;
   capacitySat: number;
   isUsable?: boolean;
@@ -275,9 +279,17 @@ export interface RlnUnspent {
   rgbAllocations?: RlnRgbAllocation[];
 }
 
+/** Canonical SCREAMING_SNAKE — normalized at the RLNBinding boundary. */
+export type RlnTransactionType =
+  | 'RGB_SEND'
+  | 'DRAIN'
+  | 'CREATE_UTXOS'
+  | 'SEND_BTC'
+  | 'INCOMING';
+
 export interface RlnTransaction {
   txid: string;
-  transactionType?: string;
+  transactionType?: RlnTransactionType;
   received?: number;
   sent?: number;
   fee?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export type {
   // New LSP types
   LspPeer,
   ReceiveStatus,
+  ReceiveSettlementOutcome,
   ChannelReadyInfo,
 } from './lsp/lsp-types';
 export { normalizeReceiveStatus, peerUri } from './lsp/lsp-types';

--- a/src/lsp/UtexoLSPClient.ts
+++ b/src/lsp/UtexoLSPClient.ts
@@ -6,6 +6,7 @@ import type {
   LspGetInfoWire,
   LspOnchainSendRequest,
   LspOnchainSendResponse,
+  LspOnchainSendWire,
   LspLightningReceiveRequest,
   LspLightningReceiveResponse,
   LspLightningReceiveWire,
@@ -121,8 +122,8 @@ export class UtexoLSPClient implements IUtexoLSPClient {
     return {
       pubkey:            raw.pubkey,
       alias:             raw.alias,
-      numChannels:       raw.num_channels       ?? raw.numChannels       ?? 0,
-      numUsableChannels: raw.num_usable_channels ?? raw.numUsableChannels ?? 0,
+      numChannels:       raw.num_channels,
+      numUsableChannels: raw.num_usable_channels,
     };
   }
 
@@ -195,10 +196,17 @@ export class UtexoLSPClient implements IUtexoLSPClient {
     };
     if (params.ln) body.lninvoice = snakeCaseLnParams(params.ln);
 
-    return this.request<LspOnchainSendResponse>('/onchain_send', {
+    const raw = await this.request<LspOnchainSendWire>('/onchain_send', {
       method: 'POST',
       body: JSON.stringify(body),
     });
+    // utexo-lsp returns snake_case keys — map explicitly
+    // (request<T>() does a plain JSON.parse with no transform).
+    return {
+      lnInvoice:  raw.ln_invoice,
+      rgbInvoice: raw.rgb_invoice,
+      mappingId:  String(raw.mapping_id),
+    };
   }
 
   /**
@@ -221,9 +229,9 @@ export class UtexoLSPClient implements IUtexoLSPClient {
       body: JSON.stringify(body),
     });
     return {
-      lnInvoice:  raw.ln_invoice  ?? raw.lnInvoice  ?? '',
-      rgbInvoice: raw.rgb_invoice ?? raw.rgbInvoice ?? '',
-      mappingId:  String(raw.mapping_id  ?? raw.mappingId  ?? ''),
+      lnInvoice:  raw.ln_invoice,
+      rgbInvoice: raw.rgb_invoice,
+      mappingId:  String(raw.mapping_id),
     };
   }
 }

--- a/src/lsp/UtexoLsp.ts
+++ b/src/lsp/UtexoLsp.ts
@@ -8,6 +8,7 @@ import {
   type ChannelReadyInfo,
   type LspOnchainSendResponse,
   type LspLnParams,
+  type ReceiveSettlementOutcome,
   normalizeReceiveStatus,
   peerUri,
 } from './lsp-types';
@@ -196,16 +197,16 @@ export class UtexoLsp {
 
   /**
    * Poll wallet.getLightningReceiveRequest until the invoice reaches a terminal
-   * state. Returns 'Succeeded' on success.
+   * state.
    *
-   * Throws LspSettlementError if status is Failed or Expired.
-   * Returns 'Succeeded' on timeout without throwing — the LSP cron may still
-   * be processing; a timeout is not a confirmed failure.
+   * @returns `'settled'` when status is Succeeded; `'timed_out'` when timeoutMs
+   *   elapses without a terminal status (LSP may still be processing).
+   * @throws LspSettlementError if status is Failed or Expired.
    */
   async awaitReceiveSettlement(
     lnInvoice: string,
     opts: WaitOptions = {},
-  ): Promise<'Succeeded'> {
+  ): Promise<ReceiveSettlementOutcome> {
     const timeoutMs      = opts.timeoutMs      ?? DEFAULT_SETTLEMENT_TIMEOUT_MS;
     const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     const deadline       = Date.now() + timeoutMs;
@@ -219,7 +220,7 @@ export class UtexoLsp {
 
       opts.onProgress?.(status);
 
-      if (status === 'Succeeded') return 'Succeeded';
+      if (status === 'Succeeded') return 'settled';
       if (status === 'Failed' || status === 'Expired') {
         throw new LspSettlementError('ln_invoice', status);
       }
@@ -228,7 +229,7 @@ export class UtexoLsp {
     }
 
     opts.onProgress?.('timeout');
-    return 'Succeeded';
+    return 'timed_out';
   }
 
   // ── 5. Outbound liquidity wait ────────────────────────────────────────────────
@@ -344,11 +345,11 @@ export class UtexoLsp {
     };
   }
 
-  // ── 9. Claim pending async payments ───────────────────────────────────────────
+  // ── 9. Claim pending HODL payments ────────────────────────────────────────────
 
   /**
-   * Find all CLAIMABLE/CLAIMING inbound payments and claim each one.
-   * Call after every unlock() when the wallet comes back online.
+   * Find all CLAIMABLE/CLAIMING inbound payments and claim each one via claimHodlInvoice.
+   * Use for invoices created with createHodlInvoice — e.g. after unlock() when back online.
    */
   async claimPendingPayments(): Promise<ClaimResult[]> {
     const payments  = await this.wallet.listPaymentsRaw();

--- a/src/lsp/UtexoLsp.ts
+++ b/src/lsp/UtexoLsp.ts
@@ -176,17 +176,26 @@ export class UtexoLsp {
   async receiveAsset(opts: ReceiveAssetOptions): Promise<ReceiveAssetResult> {
     const expirySeconds = opts.expirySeconds ?? 3600;
 
+    const createdAtMs = Date.now();
     const { lnInvoice } = await this.wallet.createLightningInvoice({
       amountSats:    opts.amountSats,
       expirySeconds,
       asset: { assetId: opts.assetId, amount: opts.amountRgb },
     });
 
+    // The LSP validates durationSeconds against the LN invoice's *remaining*
+    // lifetime (EXPIRY_MATCH_TOLERANCE_SEC, default 5s). Invoice creation on a
+    // mobile node can take several seconds, so send the remaining lifetime —
+    // sending the full expiry fails with HTTP 400 once creation outlasts the
+    // tolerance.
+    const elapsedSeconds = Math.round((Date.now() - createdAtMs) / 1000);
+    const durationSeconds = Math.max(1, expirySeconds - elapsedSeconds);
+
     const lr = await this.http.lightningReceive({
       lnInvoice,
       rgb: {
-        assetId:         opts.assetId,
-        durationSeconds: expirySeconds,
+        assetId: opts.assetId,
+        durationSeconds,
       },
     });
 

--- a/src/lsp/lsp-types.ts
+++ b/src/lsp/lsp-types.ts
@@ -22,10 +22,8 @@ export interface LspGetInfoResponse {
 export interface LspGetInfoWire {
   pubkey: string;
   alias?: string;
-  num_channels?: number;
-  numChannels?: number;
-  num_usable_channels?: number;
-  numUsableChannels?: number;
+  num_channels: number;
+  num_usable_channels: number;
 }
 
 export interface LspLnParams {
@@ -68,14 +66,18 @@ export interface LspLightningReceiveResponse {
   mappingId: string;
 }
 
-/** Raw wire shape returned by utexo-lsp (snake_case keys). */
+/** Raw wire shape returned by utexo-lsp `/lightning_receive` (snake_case keys). */
 export interface LspLightningReceiveWire {
-  ln_invoice?: string;
-  lnInvoice?: string;
-  rgb_invoice?: string;
-  rgbInvoice?: string;
-  mapping_id?: string | number;
-  mappingId?: string | number;
+  ln_invoice: string;
+  rgb_invoice: string;
+  mapping_id: string | number;
+}
+
+/** Raw wire shape returned by utexo-lsp `/onchain_send` (snake_case keys). */
+export interface LspOnchainSendWire {
+  ln_invoice: string;
+  rgb_invoice: string;
+  mapping_id: string | number;
 }
 
 export interface LspLnurlpCallbackResponse {

--- a/src/lsp/lsp-types.ts
+++ b/src/lsp/lsp-types.ts
@@ -118,6 +118,9 @@ export function peerUri(peer: LspPeer): string {
 
 export type ReceiveStatus = 'Pending' | 'Succeeded' | 'Failed' | 'Expired';
 
+/** Result of awaitReceiveSettlement — distinct from wallet ReceiveStatus. */
+export type ReceiveSettlementOutcome = 'settled' | 'timed_out';
+
 export function normalizeReceiveStatus(raw: string | null | undefined): ReceiveStatus {
   const s = (raw ?? '').toUpperCase();
   if (s === 'SUCCEEDED' || s === 'SETTLED') return 'Succeeded';

--- a/src/wallet/utexo-wallet.ts
+++ b/src/wallet/utexo-wallet.ts
@@ -115,6 +115,13 @@ export interface RlnOnchainSendRequestModel extends OnchainSendRequestModel {
   skipSync?: boolean;
 }
 
+export interface RlnCreateLightningInvoiceRequestModel
+  extends Omit<CreateLightningInvoiceRequestModel, 'asset'> {
+  /** Omit for a plain BTC invoice — RLN supports asset-less BOLT11 invoices
+   *  (core types `asset` as required, but the runtime maps absence to null). */
+  asset?: CreateLightningInvoiceRequestModel['asset'];
+}
+
 // ── Constructor params ────────────────────────────────────────────────────────
 
 export interface UTEXOWalletNodeParams {
@@ -730,7 +737,7 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
   // ── IUTEXOProtocol — Lightning ────────────────────────────────────────────
 
   async createLightningInvoice(
-    params: CreateLightningInvoiceRequestModel & {
+    params: RlnCreateLightningInvoiceRequestModel & {
       paymentHash?: string | null;
       minFinalCltvExpiryDelta?: number | null;
     }

--- a/src/wallet/utexo-wallet.ts
+++ b/src/wallet/utexo-wallet.ts
@@ -200,17 +200,19 @@ function mapUtxo(u: RlnUnspent): Unspent {
 }
 
 function mapTransaction(t: RlnTransaction): Transaction {
-  const validTypes: TransactionType[] = [
-    'RgbSend',
-    'Drain',
-    'CreateUtxos',
-    'User',
-  ];
+  // RLNBinding canonicalizes the native enum to SCREAMING_SNAKE; map it onto
+  // the core TransactionType vocabulary (SEND_BTC/INCOMING have no core
+  // counterpart and fold into 'User').
+  const typeMap: Record<string, TransactionType> = {
+    RGB_SEND: 'RgbSend',
+    DRAIN: 'Drain',
+    CREATE_UTXOS: 'CreateUtxos',
+    SEND_BTC: 'User',
+    INCOMING: 'User',
+  };
   return {
     txid: t.txid,
-    transactionType: (validTypes.includes(t.transactionType as TransactionType)
-      ? t.transactionType
-      : 'User') as TransactionType,
+    transactionType: typeMap[t.transactionType ?? ''] ?? 'User',
     received: t.received ?? 0,
     sent: t.sent ?? 0,
     fee: t.fee ?? 0,


### PR DESCRIPTION
## 1.0.0-beta.14

__added__
- Plain BTC Lightning invoices — `createLightningInvoice` now accepts requests without `asset` (`RlnCreateLightningInvoiceRequestModel`).
- `listChannels` returns previously missing fields on both platforms: `status`, `nextOutboundHtlcLimitMsat`, `nextOutboundHtlcMinimumMsat`, `peerAlias`, `shortChannelId`, `virtualOpenMode` (host-side only).
- Canonical enum unions: `RlnTransactionType`, `RlnChannelStatus`.

__fixed__
- iOS/Android enum case divergence — enum-as-string results normalized at the `RLNBinding` boundary (`rlnInvoiceStatus`, `rlnSendPayment`, `rlnKeysend`, channel `status`, `transactionType`). Fixes settlement polling stuck on `Pending` on iOS.
- `listTransactions` — transaction types no longer collapse to `'User'`; native values map correctly onto core `TransactionType`.
- `UtexoLsp.receiveAsset` — sends the LN invoice's remaining lifetime as `durationSeconds`; full expiry failed utexo-lsp's expiry-match validation (HTTP 400) on slow invoice creation.
- `UtexoLSPClient.onchainSend` — response fields were always `undefined` (snake_case wire keys); now mapped explicitly.
- iOS build error in `Rgb.mm` — `bitcoindRpcPort` nullability conflict with the codegen protocol.

__changed__
- `UtexoLSPClient` (`getInfo`, `lightningReceive`, `onchainSend`) — strict snake_case wire parsing, defensive fallback chains removed.