### PR TITLE
Feat: External signer apay fixes & lsp UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,19 @@
 ## 1.0.0-beta.17
 
 __added__
-- Per-network default `lspBaseUrl` — `network: 'utexo'` now resolves to `https://lsp-signet.utexo.com` when `lspBaseUrl` is omitted. New helpers in `src/wallet/network-defaults.ts`: `getDefaultLspBaseUrl(network)` and `resolveLspBaseUrl(network, lspBaseUrl?)` (the latter throws when neither an explicit value nor a network default exists). `lspBaseUrl` is now optional on networks that have a default.
+- **`apayNewWithAddress(hostNodeId, username, domain)`** on `UTEXOWallet` — registers an async-payment hash pool together with a Lightning Address attestation (`address_sig`). Required for APay hash-substitution resistance; works with password and external signers. Native bridge: `rlnApayNewWithAddress` on iOS and Android.
+- **`UtexoLsp.refillHashPool()`** — tops up the APay hash pool with a fresh attested batch when `unusedHashes` runs low.
+- **`ApayInvoiceProof`** / **`ApayMerkleProofElement`** types — Merkle proof returned on LNURL-pay callbacks so payers can verify the payment hash before paying.
+- Per-network default `lspBaseUrl` — `network: 'utexo'` resolves to `https://lsp-signet.utexo.com` when `lspBaseUrl` is omitted. Helpers in `src/wallet/network-defaults.ts`: `getDefaultLspBaseUrl(network)` and `resolveLspBaseUrl(network, lspBaseUrl?)` (throws when neither an explicit value nor a network default exists).
 
 __changed__
-- `createLsp()` now auto-wires virtual channels: it fetches the LSP node pubkey (`GET /get_info`), sets `enableVirtualChannelsV0: true`, and adds that pubkey to `virtualPeerPubkeys` on the node params. Callers no longer need to fetch the LSP pubkey or set those flags manually for LSP-backed virtual channels.
+- **`UtexoLsp.enableLightningAddress()`** — now polls the LSP for a provisioned username/domain (`getLightningAddressByPubkey`), then registers a single attested batch via `apayNewWithAddress` (no bootstrap `apayNew` first — avoids `invalid_hash_batch` overflow). Returns `unusedHashes`, `nextIndexExpected`, and `refillBatchSize` from the pool response.
+- **`createLsp()`** — auto-wires virtual channels: fetches the LSP pubkey (`GET /get_info`), sets `enableVirtualChannelsV0: true`, and adds that pubkey to `virtualPeerPubkeys`. Callers no longer need to fetch the LSP pubkey manually for LSP-backed virtual channels.
+- **`UtexoLSPClient`** — explicit snake_case wire mapping for `getLightningAddressByPubkey` (`recipient_pubkey`, `address_sig`) and LNURL-pay callbacks (`proof` → `ApayInvoiceProof`). Fixes fields that were `undefined` against utexo-lsp >= 0.6.
+- Bumped RLN native bindings to **v0.6.0-beta.2** (from `0.6.0-beta.1`).
 
 __breaking__
-- Because virtual-channel params are baked into the node at `init()`, **`createLsp()` must now be called before `init()`/`reinit()`**. Calling it after the node is created throws. Update any `init() → createLsp()` ordering to `createLsp() → init()`.
+- **`createLsp()` must be called before `init()`/`reinit()`** — virtual-channel params are baked into the node at init time. Calling `createLsp()` after the node exists throws. Update any `init() → createLsp()` ordering to `createLsp() → init()`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.0.0-beta.17
+
+__added__
+- Per-network default `lspBaseUrl` — `network: 'utexo'` now resolves to `https://lsp-signet.utexo.com` when `lspBaseUrl` is omitted. New helpers in `src/wallet/network-defaults.ts`: `getDefaultLspBaseUrl(network)` and `resolveLspBaseUrl(network, lspBaseUrl?)` (the latter throws when neither an explicit value nor a network default exists). `lspBaseUrl` is now optional on networks that have a default.
+
+__changed__
+- `createLsp()` now auto-wires virtual channels: it fetches the LSP node pubkey (`GET /get_info`), sets `enableVirtualChannelsV0: true`, and adds that pubkey to `virtualPeerPubkeys` on the node params. Callers no longer need to fetch the LSP pubkey or set those flags manually for LSP-backed virtual channels.
+
+__breaking__
+- Because virtual-channel params are baked into the node at `init()`, **`createLsp()` must now be called before `init()`/`reinit()`**. Calling it after the node is created throws. Update any `init() → createLsp()` ordering to `createLsp() → init()`.
+
+---
+
 ## 1.0.0-beta.14
 
 __added__

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,9 @@ On cold start (after `shutdown`), `NativeExternalRLNSigner.unlockNode` recreates
 
 **iOS**: `Rgb.mm` (ObjC++ bridge) dispatches to `RgbSwiftHelper.swift` synchronous static methods, returning NSDictionary results. The `.mm` file bridges async Promise calls into those sync helpers via Grand Central Dispatch.
 
-**Android**: `RgbModule.kt` extends the codegen-generated `NativeRgbSpec`, dispatches each bridge call via Kotlin coroutines (`Dispatchers.IO`). The Android binding (`com.utexo:rgb-lightning-node-android:0.5.0-beta.1`) is resolved from Maven Central. JNA (`net.java.dev.jna:jna:5.17.0@aar`) is required for UniFFI.
+**Android**: `RgbModule.kt` extends the codegen-generated `NativeRgbSpec`, dispatches each bridge call via Kotlin coroutines (`Dispatchers.IO`). The Android binding (`com.utexo:rgb-lightning-node-android:0.6.0-beta.2`) is resolved from Maven Central. JNA (`net.java.dev.jna:jna:5.17.0@aar`) is required for UniFFI.
 
-**iOS native framework**: `RGBLightningNode.xcframework` is downloaded from GitHub releases during `postinstall` (`scripts/download-rln-bindings.js`). It is not committed. Version is pinned at `0.5.0-beta.1`. For local development with a custom build, place `swift-release.zip` at `src/bindings/swift-release.zip` — the script will use it instead.
+**iOS native framework**: `RGBLightningNode.xcframework` is downloaded from GitHub releases during `postinstall` (`scripts/download-rln-bindings.js`). It is not committed. Version is pinned at `0.6.0-beta.2`. For local development with a custom build, place `swift-release.zip` at `src/bindings/swift-release.zip` — the script will use it instead.
 
 ### Type mapping
 

--- a/Readme.md
+++ b/Readme.md
@@ -138,7 +138,7 @@ const wallet = new UTEXOWallet(
 | `vssUrl` | `string?` | VSS server URL for encrypted remote backup |
 | `vssAllowHttp` | `boolean?` | Allow plain HTTP VSS endpoint (default `false`) |
 | `vssAllowEmptyRestore` | `boolean?` | Allow restoring from VSS when no backup exists yet (default `false`) |
-| `lspBaseUrl` | `string?` | LSP base URL — required for `createLsp()` and APay |
+| `lspBaseUrl` | `string?` | LSP base URL for `createLsp()` and APay. Optional on networks with a default (e.g. `utexo` → `https://lsp-signet.utexo.com`); required otherwise |
 | `lspBearerToken` | `string?` | LSP bearer token — required for APay |
 
 ---
@@ -300,7 +300,7 @@ await wallet.destroy();
 
 | Method | Description |
 |--------|-------------|
-| `createLsp(peer?)` | Create an `UtexoLsp` session. No-arg: discovers peer from `lspBaseUrl` + `GET /get_info`. Pass `LspPeer` to override. |
+| `createLsp(peer?)` | Create an `UtexoLsp` session. No-arg: discovers peer from `lspBaseUrl` (or the network default) + `GET /get_info`, and auto-enables virtual channels (`enableVirtualChannelsV0: true` + adds the LSP pubkey to `virtualPeerPubkeys`). Pass `LspPeer` to override. **Must be called before `init()`/`reinit()`.** |
 | `getLspConfig()` | Return `{ baseUrl, bearerToken }` this node was initialized with |
 | `apayNewWithAddress(hostNodeId, username, domain)` | Register an attested hash pool (signs `address_sig`) — hash-substitution resistant |
 | `apayNew(hostNodeId)` | Register a hash pool without an address attestation |
@@ -813,21 +813,24 @@ const { txid: paymentHash } = await wallet.payLightningInvoice({ lnInvoice });
 ### Setup
 
 ```typescript
-// Wallet must include lspBaseUrl — required for no-arg createLsp() and APay
+// lspBaseUrl is optional on networks with a default (utexo → https://lsp-signet.utexo.com);
+// set it explicitly for other networks or to override.
 const wallet = new UTEXOWallet({
   ...nodeParams,
-  lspBaseUrl:     'https://lsp-signet.utexo.com',
+  network:        'utexo',
   lspBearerToken: 'bearer-token', // only required for APay
+  // lspBaseUrl: 'https://lsp-signet.utexo.com', // optional on utexo
 }, signer);
+
+// createLsp() MUST be called before init(): it discovers the LSP pubkey
+// (GET /get_info) and auto-wires virtual channels (enableVirtualChannelsV0 +
+// virtualPeerPubkeys) into the node params, which are baked in at init().
+const lsp = await wallet.createLsp();
 
 await wallet.init();
 await wallet.unlock(unlockParams);
 
-// No-arg form — discovers peer pubkey from GET /get_info,
-// host from lspBaseUrl, port defaults to 9735
-const lsp = await wallet.createLsp();
-
-// Or pass explicit peer to override any field
+// Or pass an explicit peer to override any field (also before init())
 const lsp = await wallet.createLsp({
   baseUrl:    'https://lsp-signet.utexo.com',
   peerPubkey: '02abc...',

--- a/Readme.md
+++ b/Readme.md
@@ -302,7 +302,8 @@ await wallet.destroy();
 |--------|-------------|
 | `createLsp(peer?)` | Create an `UtexoLsp` session. No-arg: discovers peer from `lspBaseUrl` + `GET /get_info`. Pass `LspPeer` to override. |
 | `getLspConfig()` | Return `{ baseUrl, bearerToken }` this node was initialized with |
-| `apayNew(hostNodeId)` | Register a hash pool with the host LSP node |
+| `apayNewWithAddress(hostNodeId, username, domain)` | Register an attested hash pool (signs `address_sig`) — hash-substitution resistant |
+| `apayNew(hostNodeId)` | Register a hash pool without an address attestation |
 | `createHodlInvoice(params)` | Create a HODL invoice tied to a specific payment hash |
 | `claimHodlInvoice(paymentHash, preimage)` | Reveal preimage to claim an inbound HODL payment |
 | `cancelHodlInvoice(paymentHash)` | Cancel a HODL invoice |
@@ -921,13 +922,26 @@ Recipient                    LSP (Host RLN)              Sender
 
 Full reference → **[docs/async-payments.md](./docs/async-payments.md)**
 
+##### `apayNewWithAddress(hostNodeId, username, domain)`
+
+Registers a hash pool together with an attestation tying it to the wallet's Lightning Address. Alongside the hashes, the node signs `username`+`domain` (`address_sig`); this signature prevents hash substitution against the address and works for both password and external signers. Resolve the username/domain from the LSP first, and keep a live P2P connection to the host during the call.
+
+```typescript
+const { username, domain } = await lsp.http.getLightningAddressByPubkey(walletPubkey);
+const pool = await wallet.apayNewWithAddress(lspPeerPubkey, username, domain);
+```
+
+Most apps reach this through the `lsp.enableLightningAddress()` / `lsp.refillHashPool()` wrappers, which handle the address lookup. Returns the same `ApayNewResponse` as `apayNew` (below).
+
 ##### `apayNew(hostNodeId)`
 
-Register a payment hash pool with the LSP host node. The host node (LSP) stores the hashes and uses them to create HODL invoices when senders pay the recipient's Lightning Address. Must be called with a live P2P connection to the host.
+Registers the same hash pool without the address attestation. The host stores the hashes and uses them to build HODL invoices when a sender pays the recipient's Lightning Address. As with `apayNewWithAddress`, it requires a live P2P connection to the host.
 
 ```typescript
 const pool = await wallet.apayNew(lspPeerPubkey);
 ```
+
+> Both calls register a hash pool. Use `apayNewWithAddress` when the batch should carry the attestation that guards against hash substitution; `apayNew` registers without it.
 
 **Returns:** `ApayNewResponse`
 
@@ -951,7 +965,7 @@ interface ApayNewResponse {
 }
 ```
 
-The `hashes` array contains the payment hashes sent to the LSP. The LSP uses them to create HODL invoices for each incoming payment to the recipient's Lightning Address. Once `unusedHashes` drops below a threshold the pool should be refilled by calling `apayNew` again.
+`hashes` holds the payment hashes the LSP now has on file; it turns each one into a HODL invoice when a sender pays the recipient's Lightning Address. When `unusedHashes` runs low, top the pool back up with `lsp.refillHashPool()`.
 
 ---
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation("com.utexo:rgb-lightning-node-android:0.5.2-beta.1")
+  implementation("com.utexo:rgb-lightning-node-android:0.6.0-beta.1")
   // UniFFI-generated RLN Kotlin bindings require JNA. Use Android AAR artifact
   // explicitly to avoid Gradle resolving both .aar and .jar variants.
   implementation "net.java.dev.jna:jna:5.17.0@aar"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation("com.utexo:rgb-lightning-node-android:0.6.0-beta.1")
+  implementation("com.utexo:rgb-lightning-node-android:0.6.0-beta.2")
   // UniFFI-generated RLN Kotlin bindings require JNA. Use Android AAR artifact
   // explicitly to avoid Gradle resolving both .aar and .jar variants.
   implementation "net.java.dev.jna:jna:5.17.0@aar"

--- a/android/src/main/java/com/rgbsdkrn/RgbModule.kt
+++ b/android/src/main/java/com/rgbsdkrn/RgbModule.kt
@@ -1239,6 +1239,48 @@ class RgbModule(reactContext: ReactApplicationContext) :
     }
   }
 
+  override fun rlnApayNewWithAddress(
+    nodeId: Double,
+    hostNodeId: String,
+    username: String,
+    domain: String,
+    promise: Promise
+  ) {
+    coroutineScope.launch(Dispatchers.IO) {
+      try {
+        val node = RlnNodeStore.get(nodeId.toInt())
+          ?: throw IllegalStateException("RLN node with id $nodeId not found")
+        android.util.Log.d("RNRgb", "rlnApayNewWithAddress: nodeId=$nodeId hostNodeId=$hostNodeId username=$username domain=$domain")
+        val res = node.apayNewWithAddress(hostNodeId, username, domain)
+        val map = Arguments.createMap()
+        map.putString("requestId", res.requestId)
+        map.putString("hostNodeId", res.hostNodeId)
+        map.putDouble("protocolVersion", res.protocolVersion.toDouble())
+        map.putString("orderId", res.orderId)
+        map.putString("status", res.status)
+        map.putDouble("acceptedThroughIndex", res.acceptedThroughIndex.toDouble())
+        map.putDouble("nextIndexExpected", res.nextIndexExpected.toDouble())
+        map.putDouble("unusedHashes", res.unusedHashes.toDouble())
+        map.putDouble("refillBatchSize", res.refillBatchSize.toDouble())
+        map.putDouble("firstHashIndex", res.firstHashIndex.toDouble())
+        map.putDouble("lastHashIndex", res.lastHashIndex.toDouble())
+        val hashesArr = Arguments.createArray()
+        res.hashes.forEach { h: AsyncOrderNewHashWire ->
+          val hMap = Arguments.createMap()
+          hMap.putDouble("hashIndex", h.hashIndex.toDouble())
+          hMap.putString("paymentHash", h.paymentHash)
+          hashesArr.pushMap(hMap)
+        }
+        map.putArray("hashes", hashesArr)
+        withContext(Dispatchers.Main) { promise.resolve(map) }
+      } catch (e: Exception) {
+        withContext(Dispatchers.Main) {
+          promise.reject(getErrorClassName(e), parseErrorMessage(e.message), e)
+        }
+      }
+    }
+  }
+
   override fun rlnRefreshTransfers(nodeId: Double, skipSync: Boolean, promise: Promise) {
     coroutineScope.launch(Dispatchers.IO) {
       try {

--- a/docs/async-payments.md
+++ b/docs/async-payments.md
@@ -45,7 +45,7 @@ flowchart TD
 
 | Step | What happens | Who drives it | SDK call |
 |------|-------------|---------------|----------|
-| **①** | Hash batch stored; Lightning Address minted | **Recipient app** | `lsp.connect()` → `lsp.enableLightningAddress()` |
+| **①** | Address provisioned on connect; attested hash batch stored | **Recipient app** | `lsp.connect()` → `lsp.enableLightningAddress()` |
 | **②** | Hash slot reserved; inbound HODL BOLT11 from Host | **Sender app** | `lsp.http.resolveAddress(username, amtMsat, assetId?, assetAmount?)` |
 | **③** | Payer pays BOLT11; inbound HTLC held at Host | **Sender app** | `lsp.waitForOutboundLiquidity(…)` then `wallet.payLightningInvoice(…)` |
 | **④** | Outbox asks Recipient for outbound invoice over P2P | **Host + utexo-lsp** | Recipient must be reachable — **`lsp.connect()`** |
@@ -54,7 +54,7 @@ flowchart TD
 
 **Blue steps (①②③)** — your app. **Green steps (④⑤⑥)** — LSP outbox; recipient app keeps **`lsp.connect()`** alive when online.
 
-When `unusedHashes` hits zero, call `apayNew` / `enableLightningAddress` again to refill.
+When `unusedHashes` runs low, call `lsp.refillHashPool()` to register a fresh attested batch.
 
 ---
 
@@ -72,11 +72,12 @@ sequenceDiagram
 
   Note over RB,L: ① Register
   RB->>RR: lsp.connect()
-  RB->>RR: apayNew / enableLightningAddress
-  RR--)H: async_order.new (P2P)
-  H->>L: POST /internal/async_order/new
+  Note over L: cron provisions account on peer connect
   RB->>L: GET /lightning_address/by_pubkey/{pubkey}
   L-->>RB: username, domain
+  RB->>RR: enableLightningAddress → apayNewWithAddress(lspPubkey, username, domain)
+  RR--)H: async_order.new + address_sig (P2P)
+  H->>L: POST /internal/async_order/new
 
   Note over SA,L: ②③ Pay (LNURL callback — no P2P to Recipient yet)
   SA->>L: LNURL /.well-known/lnurlp/{username}
@@ -139,22 +140,24 @@ Explicit `LspPeer` + `createLsp(LSP_PEER)` is still valid when you cannot set `l
 Both sides need an RGB channel first: `lsp.connect()` → `lsp.waitForChannel(assetId, { … })`.
 
 ```typescript
-await lsp.connect();
+await lsp.connect();  // connect first — the LSP mints the address only for connected peers
 
-// Recommended: apayNew + getLightningAddressByPubkey in one call
+// Resolves the minted address, then registers one attested batch:
 const { address } = await lsp.enableLightningAddress();
 console.log(`Lightning Address: ${address}`);
 
-// Keep calling lsp.connect() while the app is foreground / expecting payments
-// so the LSP outbox can reach the node over P2P when a payer pays.
+// Keep calling lsp.connect() while the app is in the foreground and expecting
+// payments, so the LSP outbox can reach the node over P2P when a payer pays.
 ```
 
-Manual alternative:
+To do it manually, resolve the address first, then register:
 
 ```typescript
-const pool = await wallet.apayNew(lspPubkey);
-const addr = await lsp.http.getLightningAddressByPubkey(walletPubkey);
+const { username, domain } = await lsp.http.getLightningAddressByPubkey(walletPubkey);
+const pool = await wallet.apayNewWithAddress(lspPubkey, username, domain);
 ```
+
+> `wallet.apayNew(lspPubkey)` registers the same pool without the address attestation (no `address_sig`). Use `apayNewWithAddress` for the attestation, which guards against hash substitution.
 
 ### ②③ Sender — LNURL pay
 
@@ -209,7 +212,7 @@ const status = await senderWallet.getLightningSendRequest(paymentHash);
 
 | | **Lightning Address (APay)** | **HODL invoice you create** |
 |---|------------------------------|-------------------------------|
-| Register | `enableLightningAddress()` / `apayNew` | `createHodlInvoice({ paymentHash, … })` |
+| Register | `enableLightningAddress()` (→ `apayNewWithAddress`) | `createHodlInvoice({ paymentHash, … })` |
 | Payer path | LNURL → Host HODL BOLT11 | Pay BOLT11 directly |
 | Recipient claim | **Automatic** (RLN auto-claim) | **`claimHodlInvoice(hash, preimage)`** |
 | Helper | — | `lsp.claimPendingPayments()` |
@@ -231,7 +234,8 @@ for (const p of await wallet.listPaymentsRaw()) {
 |--------|------|-------------|
 | `lsp.connect()` | ①④ | Lightning P2P to Host — call before register and when coming online |
 | `lsp.waitForChannel(assetId)` | ①③ | Wait for usable RGB channel |
-| `lsp.enableLightningAddress()` | ① | `apayNew` + `getLightningAddressByPubkey` |
+| `lsp.enableLightningAddress()` | ① | `getLightningAddressByPubkey` (poll) → `apayNewWithAddress` |
+| `lsp.refillHashPool()` | ① | Top up the hash pool with a fresh attested batch |
 | `lsp.http.resolveAddress(…)` | ② | LNURL callback → HODL BOLT11 |
 | `lsp.waitForOutboundLiquidity(msat)` | ③ | Confirm sender can route before pay |
 | `wallet.payLightningInvoice(…)` | ③ | Pay HODL invoice |
@@ -262,4 +266,4 @@ for (const p of await wallet.listPaymentsRaw()) {
 |--------|------|------|
 | GET | `/.well-known/lnurlp/{username}` | ② LNURL metadata |
 | GET | `/pay/callback/{username}?amount=…&asset_id=…&asset_amount=…` | ② HODL BOLT11 |
-| GET | `/lightning_address/by_pubkey/{pubkey}` | ① discovery after register |
+| GET | `/lightning_address/by_pubkey/{pubkey}` | ① discovery before register (address provisioned on connect) |

--- a/docs/async-payments.md
+++ b/docs/async-payments.md
@@ -110,14 +110,16 @@ sequenceDiagram
 ```typescript
 const wallet = new UTEXOWallet({
   ...nodeParams,
-  lspBaseUrl:     'https://lsp-signet.utexo.com',
+  network:        'utexo',          // lspBaseUrl optional on utexo (defaults to https://lsp-signet.utexo.com)
   lspBearerToken: 'bearer-token',
 }, signer);
 
+// createLsp() before init(): discovers pubkey/host from lspBaseUrl + GET /get_info
+// and auto-wires virtual channels into the node params.
+const lsp = await wallet.createLsp();
+
 await wallet.init();
 await wallet.unlock(unlockParams);
-
-const lsp = await wallet.createLsp();  // discovers pubkey/host from lspBaseUrl + GET /get_info
 ```
 
 **Regtest local demo** (virtual 0-conf channels — not required on signet):

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -202,13 +202,29 @@ const { username, domain, address } = await lsp.enableLightningAddress();
 // address → 'excited-mountain-1234@lsp-signet.utexo.com'
 ```
 
-Internally:
-1. Fetches the wallet's own pubkey via `wallet.getNodeInfo()`
-2. Fetches LSP pubkey via `lsp.http.getInfo()`
-3. Calls `wallet.apayNew(lspPubkey)` — sends hashes to the LSP via P2P onion messages
-4. Calls `lsp.http.getLightningAddressByPubkey(walletPubkey)` — returns the assigned address
+How it works:
 
-The `lspBaseUrl` **and** `lspBearerToken` on the wallet node params must be set for step 3 to work (it routes through the native RLN node, not the HTTP client).
+The LSP mints a Lightning Address for every peer that connects, so the address exists before registration — the method only has to look it up. It reads the wallet pubkey (`getNodeInfo`) and the LSP pubkey (`getInfo`), then polls `getLightningAddressByPubkey` until the address appears. `lsp.connect()` must run first; until the account exists the lookup returns 404.
+
+With the `username` and `domain` resolved, it calls `wallet.apayNewWithAddress(lspPubkey, username, domain)`, which sends a single signed batch of hashes to the LSP over P2P. The node signs `username`+`domain` (`address_sig`) and attaches it to the batch. This signature makes the pool resistant to hash substitution and works for both password and external signers.
+
+Returns `{ username, domain, address, unusedHashes, nextIndexExpected, refillBatchSize }`.
+
+Both `lspBaseUrl` and `lspBearerToken` must be set on the wallet node params — registration runs through the native RLN node, not the HTTP client.
+
+> Register exactly one batch. The node's batch size already matches the LSP's pool cap, so a single batch fills it. Issuing an `apayNew` bootstrap first overflows the pool, and the LSP rejects the second batch with `invalid_hash_batch`.
+
+---
+
+### `refillHashPool()`
+
+Tops up the hash pool with a fresh signed batch. Call it after `enableLightningAddress()` once `unusedHashes` runs low.
+
+```typescript
+const { unusedHashes, nextIndexExpected, refillBatchSize } = await lsp.refillHashPool();
+```
+
+The address is already minted, so the method re-resolves it and registers another batch through `apayNewWithAddress`. Refills therefore carry the same attestation as the initial registration. Prefer this over calling `apayNew` directly.
 
 ---
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -12,18 +12,21 @@
 ```typescript
 import { UTEXOWallet } from '@utexo/rgb-sdk-rn';
 
-// lspBaseUrl is required — wires the native RLN for APay and
-// is the source for no-arg createLsp() peer discovery
+// lspBaseUrl wires the native RLN for APay and is the source for no-arg
+// createLsp() peer discovery. Optional on networks with a default (utexo →
+// https://lsp-signet.utexo.com); required otherwise.
 const wallet = new UTEXOWallet({
   ...nodeParams,
-  lspBaseUrl:     'https://lsp-signet.utexo.com',
+  network:        'utexo',
   lspBearerToken: 'bearer-token',  // only required for APay
 }, signer);
+
+// No-arg: peer pubkey from GET /get_info, host from lspBaseUrl, port 9735.
+// MUST be called before init() — it auto-wires virtual channels into node params.
+const lsp = await wallet.createLsp();
+
 await wallet.init();
 await wallet.unlock(unlockParams);
-
-// No-arg: peer pubkey from GET /get_info, host from lspBaseUrl, port 9735
-const lsp = await wallet.createLsp();
 ```
 
 If you need to override any peer detail:
@@ -342,13 +345,15 @@ await wallet.payLightningInvoice({ lnInvoice });
 ```typescript
 const wallet = new UTEXOWallet({
   ...nodeParams,
-  lspBaseUrl:     'https://lsp-signet.utexo.com',
+  network:        'utexo',          // lspBaseUrl optional on utexo (defaults to https://lsp-signet.utexo.com)
   lspBearerToken: 'bearer-token',
 }, signer);
+
+// createLsp() before init() — auto-wires virtual channels into node params
+const lsp = await wallet.createLsp();  // or createLsp(undefined, 9737) on regtest
+
 await wallet.init();
 await wallet.unlock(unlockParams);
-
-const lsp = await wallet.createLsp();  // or createLsp(undefined, 9737) on regtest
 
 await lsp.connect();
 await lsp.waitForChannel(ASSET_ID, { onProgress: (m) => console.log(m) });

--- a/ios/RGBLightningNode.swift
+++ b/ios/RGBLightningNode.swift
@@ -875,6 +875,8 @@ public protocol SdkNodeProtocol: AnyObject {
 
     func apayNew(hostNodeId: String) throws -> AsyncOrderNewResponse
 
+    func apayNewWithAddress(hostNodeId: String, username: String, domain: String) throws -> AsyncOrderNewResponse
+
     func assetBalance(assetId: ContractId) throws -> AssetBalanceInfo
 
     func assetMetadata(assetId: ContractId) throws -> AssetMetadataInfo
@@ -1067,6 +1069,15 @@ open class SdkNode:
         return try FfiConverterTypeAsyncOrderNewResponse.lift(rustCallWithError(FfiConverterTypeRlnError.lift) {
             uniffi_rgb_lightning_node_fn_method_sdknode_apay_new(self.uniffiClonePointer(),
                                                                  FfiConverterString.lower(hostNodeId), $0)
+        })
+    }
+
+    open func apayNewWithAddress(hostNodeId: String, username: String, domain: String) throws -> AsyncOrderNewResponse {
+        return try FfiConverterTypeAsyncOrderNewResponse.lift(rustCallWithError(FfiConverterTypeRlnError.lift) {
+            uniffi_rgb_lightning_node_fn_method_sdknode_apay_new_with_address(self.uniffiClonePointer(),
+                                                                              FfiConverterString.lower(hostNodeId),
+                                                                              FfiConverterString.lower(username),
+                                                                              FfiConverterString.lower(domain), $0)
         })
     }
 
@@ -10426,6 +10437,9 @@ private var initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_rgb_lightning_node_checksum_method_sdknode_apay_new() != 7684 {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if uniffi_rgb_lightning_node_checksum_method_sdknode_apay_new_with_address() != 24879 {
         return InitializationResult.apiChecksumMismatch
     }
     if uniffi_rgb_lightning_node_checksum_method_sdknode_asset_balance() != 20956 {

--- a/ios/Rgb.mm
+++ b/ios/Rgb.mm
@@ -734,6 +734,24 @@ minFinalCltvExpiryDelta:(NSNumber *)minFinalCltvExpiryDelta
     });
 }
 
+- (void)rlnApayNewWithAddress:(double)nodeId
+                   hostNodeId:(NSString *)hostNodeId
+                     username:(NSString *)username
+                       domain:(NSString *)domain
+                      resolve:(RCTPromiseResolveBlock)resolve
+                       reject:(RCTPromiseRejectBlock)reject
+{
+    EXEC_ASYNC({
+        NSDictionary *result = [RgbSwiftHelper _rlnApayNewWithAddress:@(nodeId) hostNodeId:hostNodeId username:username domain:domain];
+        NSString *errorMessage = result[@"error"];
+        if (errorMessage != nil) {
+            reject(result[@"errorCode"] ?: @"RLN_APAY_NEW_ERROR", errorMessage, nil);
+        } else {
+            resolve(result);
+        }
+    });
+}
+
 - (void)rlnRefreshTransfers:(double)nodeId
                     skipSync:(BOOL)skipSync
                      resolve:(RCTPromiseResolveBlock)resolve

--- a/ios/RgbSwiftHelper.swift
+++ b/ios/RgbSwiftHelper.swift
@@ -893,6 +893,35 @@ public class RgbSwiftHelper: NSObject {
     }
   }
 
+  @objc(_rlnApayNewWithAddress:hostNodeId:username:domain:)
+  public static func _rlnApayNewWithAddress(_ nodeId: NSNumber, hostNodeId: String, username: String, domain: String) -> NSDictionary {
+    do {
+      guard let node = RlnNodeStore.shared.get(id: nodeId.intValue) else {
+        return ["error": "RLN node with id \(nodeId) not found"] as NSDictionary
+      }
+      let res = try node.apayNewWithAddress(hostNodeId: hostNodeId, username: username, domain: domain)
+      let hashes = res.hashes.map { h -> [String: Any] in
+        ["hashIndex": h.hashIndex, "paymentHash": h.paymentHash]
+      }
+      return [
+        "requestId": res.requestId,
+        "hostNodeId": res.hostNodeId,
+        "protocolVersion": res.protocolVersion,
+        "orderId": res.orderId,
+        "status": res.status,
+        "acceptedThroughIndex": res.acceptedThroughIndex,
+        "nextIndexExpected": res.nextIndexExpected,
+        "unusedHashes": res.unusedHashes,
+        "refillBatchSize": res.refillBatchSize,
+        "firstHashIndex": res.firstHashIndex,
+        "lastHashIndex": res.lastHashIndex,
+        "hashes": hashes,
+      ] as NSDictionary
+    } catch {
+      return ["error": parseErrorMessage(error), "errorCode": getErrorClassName(error)] as NSDictionary
+    }
+  }
+
   @objc(_rlnRefreshTransfers:skipSync:)
   public static func _rlnRefreshTransfers(_ nodeId: NSNumber, skipSync: Bool) -> NSDictionary {
     do {

--- a/scripts/download-rln-bindings.js
+++ b/scripts/download-rln-bindings.js
@@ -7,7 +7,7 @@ const { execSync } = require('child_process');
 // or used from a local zip in src/bindings/ if present.
 // Android AAR is resolved from Maven Central by Gradle — no download needed here.
 
-const VERSION = '0.6.0-beta.1';
+const VERSION = '0.6.0-beta.2';
 const BASE_URL = `https://github.com/UTEXO-Protocol/rgb-lightning-node/releases/download/v${VERSION}`;
 
 const ROOT = path.join(__dirname, '..');
@@ -23,7 +23,7 @@ function downloadFile(url, dest) {
     const file = fs.createWriteStream(dest);
 
     const req = https
-      .get(url, { timeout: 30000 }, (response) => {
+      .get(url, { timeout: 60000 }, (response) => {
         if (response.statusCode === 301 || response.statusCode === 302) {
           file.close();
           fs.unlinkSync(dest);

--- a/scripts/download-rln-bindings.js
+++ b/scripts/download-rln-bindings.js
@@ -7,7 +7,7 @@ const { execSync } = require('child_process');
 // or used from a local zip in src/bindings/ if present.
 // Android AAR is resolved from Maven Central by Gradle — no download needed here.
 
-const VERSION = '0.5.2-beta.1';
+const VERSION = '0.6.0-beta.1';
 const BASE_URL = `https://github.com/UTEXO-Protocol/rgb-lightning-node/releases/download/v${VERSION}`;
 
 const ROOT = path.join(__dirname, '..');

--- a/src/binding/IRLN.ts
+++ b/src/binding/IRLN.ts
@@ -162,6 +162,12 @@ export interface IRLN {
 
   rlnApayNew(hostNodeId: string): Promise<RlnApayNewResponse>;
 
+  rlnApayNewWithAddress(
+    hostNodeId: string,
+    username: string,
+    domain: string
+  ): Promise<RlnApayNewResponse>;
+
   rlnDecodeLnInvoice(invoice: string): Promise<RlnDecodeLnInvoiceResponse>;
   rlnDecodeRgbInvoice(invoice: string): Promise<RlnDecodeRgbInvoiceResponse>;
 

--- a/src/binding/NativeRgb.ts
+++ b/src/binding/NativeRgb.ts
@@ -156,6 +156,12 @@ export interface Spec extends TurboModule {
   ): Promise<object>;
   rlnCancelHodlInvoice(nodeId: number, paymentHash: string): Promise<void>;
   rlnApayNew(nodeId: number, hostNodeId: string): Promise<object>;
+  rlnApayNewWithAddress(
+    nodeId: number,
+    hostNodeId: string,
+    username: string,
+    domain: string
+  ): Promise<object>;
   rlnRefreshTransfers(nodeId: number, skipSync: boolean): Promise<void>;
   rlnRgbInvoice(
     nodeId: number,

--- a/src/binding/RLNBinding.ts
+++ b/src/binding/RLNBinding.ts
@@ -475,6 +475,16 @@ export class RLNBinding implements IRLN {
     ) as Promise<RlnApayNewResponse>;
   }
 
+  async rlnApayNewWithAddress(
+    hostNodeId: string,
+    username: string,
+    domain: string
+  ): Promise<RlnApayNewResponse> {
+    return this.withNodeOperation((nodeId) =>
+      Rgb.rlnApayNewWithAddress(nodeId, hostNodeId, username, domain)
+    ) as Promise<RlnApayNewResponse>;
+  }
+
   async rlnDecodeLnInvoice(
     invoice: string
   ): Promise<RlnDecodeLnInvoiceResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ export type {
   HodlInvoiceResult,
   ApayHashEntry,
   ApayNewResponse,
+  ApayInvoiceProof,
+  ApayMerkleProofElement,
   // New LSP types
   LspPeer,
   ReceiveStatus,

--- a/src/lsp/UtexoLSPClient.ts
+++ b/src/lsp/UtexoLSPClient.ts
@@ -11,8 +11,40 @@ import type {
   LspLightningReceiveResponse,
   LspLightningReceiveWire,
   LspLightningAddressByPubkeyResponse,
+  LspLightningAddressByPubkeyWire,
   LspLnurlpCallbackResponse,
+  LspLnurlpCallbackWire,
+  LspApayInvoiceProofWire,
+  ApayInvoiceProof,
 } from './lsp-types';
+
+/**
+ * Map the snake_case wire proof (utexo-lsp) to the camelCase SDK shape.
+ * request<T>() does a plain JSON.parse with no key transform, so this must
+ * be explicit (same pattern as the rest of this client).
+ */
+function mapApayProof(
+  raw: LspApayInvoiceProofWire | undefined
+): ApayInvoiceProof | undefined {
+  if (!raw) return undefined;
+  return {
+    version: raw.version,
+    recipientPubkey: raw.recipient_pubkey,
+    hostPubkey: raw.host_pubkey,
+    batchId: raw.batch_id,
+    hashIndex: raw.hash_index,
+    paymentHash: raw.payment_hash,
+    batchRoot: raw.batch_root,
+    batchSize: raw.batch_size,
+    merkleProof: (raw.merkle_proof ?? []).map((e) => ({
+      sibling: e.sibling,
+      side: e.side,
+    })),
+    batchSig: raw.batch_sig,
+    createdAt: raw.created_at,
+    expiresAt: raw.expires_at,
+  };
+}
 
 const DEFAULT_TIMEOUT_MS = 15_000;
 
@@ -148,7 +180,14 @@ export class UtexoLSPClient implements IUtexoLSPClient {
     let url = `${this.rewriteCallbackUrl(meta.callback)}${sep}amount=${amtMsat}`;
     if (assetId) url += `&asset_id=${encodeURIComponent(assetId)}`;
     if (assetAmount !== undefined) url += `&asset_amount=${assetAmount}`;
-    return this.request<LspLnurlpCallbackResponse>(url);
+    const raw = await this.request<LspLnurlpCallbackWire>(url);
+    return {
+      pr: raw.pr,
+      routes: raw.routes ?? [],
+      status: raw.status,
+      reason: raw.reason,
+      proof: mapApayProof(raw.proof),
+    };
   }
 
   /**
@@ -165,7 +204,14 @@ export class UtexoLSPClient implements IUtexoLSPClient {
     let path = `/pay/callback/${encodeURIComponent(username)}?amount=${amtMsat}`;
     if (assetId) path += `&asset_id=${encodeURIComponent(assetId)}`;
     if (assetAmount !== undefined) path += `&asset_amount=${assetAmount}`;
-    return this.request<LspLnurlpCallbackResponse>(path);
+    const raw = await this.request<LspLnurlpCallbackWire>(path);
+    return {
+      pr: raw.pr,
+      routes: raw.routes ?? [],
+      status: raw.status,
+      reason: raw.reason,
+      proof: mapApayProof(raw.proof),
+    };
   }
 
   async getLightningAddressByPubkey(
@@ -175,9 +221,15 @@ export class UtexoLSPClient implements IUtexoLSPClient {
     if (!pubkey) {
       throw new Error('getLightningAddressByPubkey: peerPubkey is required');
     }
-    return this.request<LspLightningAddressByPubkeyResponse>(
+    const raw = await this.request<LspLightningAddressByPubkeyWire>(
       `/lightning_address/by_pubkey/${encodeURIComponent(pubkey)}`
     );
+    return {
+      username: raw.username,
+      domain: raw.domain,
+      recipientPubkey: raw.recipient_pubkey,
+      addressSig: raw.address_sig,
+    };
   }
 
   /**

--- a/src/lsp/UtexoLsp.ts
+++ b/src/lsp/UtexoLsp.ts
@@ -9,6 +9,7 @@ import {
   type LspOnchainSendResponse,
   type LspLnParams,
   type ReceiveSettlementOutcome,
+  type ApayNewResponse,
   normalizeReceiveStatus,
   peerUri,
 } from './lsp-types';
@@ -78,6 +79,12 @@ export interface LightningAddressInfo {
   domain: string;
   /** Convenience: username@domain */
   address: string;
+  /** Hashes still available in the pool after registration — drive refills off this. */
+  unusedHashes?: number;
+  /** Hash index the next batch will start from. */
+  nextIndexExpected?: number;
+  /** LSP-suggested size for the next refill batch. */
+  refillBatchSize?: number;
 }
 
 // ── claimPendingPayments ──────────────────────────────────────────────────────
@@ -334,9 +341,22 @@ export class UtexoLsp {
   // ── 8. Async / offline receive (APay) ─────────────────────────────────────────
 
   /**
-   * Register async payment hash pool with this LSP then fetch the auto-generated
-   * Lightning Address for this wallet's pubkey.
+   * Register the async-payment hash pool with this LSP and return the
+   * auto-generated Lightning Address for this wallet's pubkey.
    * Call once after first unlock to enable offline receive.
+   *
+   * The LSP provisions the address account (and mints the username) for every
+   * connected peer via its own cron, so the username already exists by the time
+   * we register — no bootstrap call is needed. We therefore:
+   *   1. Resolve username/domain via getLightningAddressByPubkey (poll briefly
+   *      in case the LSP cron hasn't provisioned the account yet).
+   *   2. Register ONE attested batch via apayNewWithAddress — the node signs the
+   *      username+domain attestation (APay hash-substitution resistance; works
+   *      for password and external signers).
+   *
+   * Important: the node's batch size equals the LSP's hash-pool cap, so a single
+   * batch fills the pool. Issuing a second batch (e.g. a bootstrap apayNew first)
+   * overflows it and the LSP rejects it with `invalid_hash_batch`.
    */
   async enableLightningAddress(): Promise<LightningAddressInfo> {
     const nodeInfo = await this.wallet.getNodeInfo();
@@ -344,14 +364,76 @@ export class UtexoLsp {
     if (!pubkey) throw new Error('enableLightningAddress: wallet not unlocked');
 
     const lspInfo = await this.http.getInfo();
-    await this.wallet.apayNew(lspInfo.pubkey);
 
-    const addr = await this.http.getLightningAddressByPubkey(pubkey);
+    // 1. Resolve the LSP-provisioned address (retry while the cron catches up).
+    const addr = await this.resolveLightningAddress(pubkey);
+
+    // 2. Register a single attested batch.
+    const pool = await this.wallet.apayNewWithAddress(
+      lspInfo.pubkey,
+      addr.username,
+      addr.domain
+    );
+
     return {
       username: addr.username,
       domain:   addr.domain,
       address:  `${addr.username}@${addr.domain}`,
+      unusedHashes:      pool.unusedHashes,
+      nextIndexExpected: pool.nextIndexExpected,
+      refillBatchSize:   pool.refillBatchSize,
     };
+  }
+
+  /**
+   * Resolve this wallet's LSP-assigned Lightning Address, retrying while the LSP
+   * cron provisions the account (getLightningAddressByPubkey 404s until then).
+   */
+  private async resolveLightningAddress(
+    pubkey: string,
+    attempts = 8,
+    delayMs = 2000
+  ): Promise<{ username: string; domain: string }> {
+    let lastErr: unknown;
+    for (let i = 0; i < attempts; i++) {
+      try {
+        const addr = await this.http.getLightningAddressByPubkey(pubkey);
+        if (addr?.username && addr?.domain) return addr;
+      } catch (e) {
+        lastErr = e;
+      }
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+    throw new Error(
+      `enableLightningAddress: LSP did not provision an address for ${pubkey} ` +
+        `(ensure the wallet is connected to the LSP). Last error: ${String(lastErr)}`
+    );
+  }
+
+  /**
+   * Top up the async-payment hash pool with a fresh signed batch.
+   *
+   * Call after {@link enableLightningAddress} when the pool runs low
+   * (see {@link ApayNewResponse.unusedHashes}). Each call registers a NEW
+   * batch — the node advances its hash index, builds a new Merkle root and
+   * signs it. Unlike the initial bootstrap, refills go straight through
+   * `apayNewWithAddress` so every batch also carries the address attestation
+   * (the username already exists, so no extra bootstrap is needed).
+   */
+  async refillHashPool(): Promise<ApayNewResponse> {
+    const nodeInfo = await this.wallet.getNodeInfo();
+    const pubkey   = String(nodeInfo?.pubkey ?? '');
+    if (!pubkey) throw new Error('refillHashPool: wallet not unlocked');
+
+    const lspInfo = await this.http.getInfo();
+    // Address was already minted by enableLightningAddress — resolve it.
+    const addr = await this.http.getLightningAddressByPubkey(pubkey);
+
+    return this.wallet.apayNewWithAddress(
+      lspInfo.pubkey,
+      addr.username,
+      addr.domain
+    );
   }
 
   // ── 9. Claim pending HODL payments ────────────────────────────────────────────

--- a/src/lsp/lsp-types.ts
+++ b/src/lsp/lsp-types.ts
@@ -80,17 +80,85 @@ export interface LspOnchainSendWire {
   mapping_id: string | number;
 }
 
+/** Wire shape of the APay invoice proof (snake_case, as utexo-lsp returns it). */
+export interface LspApayInvoiceProofWire {
+  version: number;
+  recipient_pubkey: string;
+  host_pubkey: string;
+  batch_id: string;
+  hash_index: number;
+  payment_hash: string;
+  batch_root: string;
+  batch_size: number;
+  merkle_proof: { sibling: string; side: string }[];
+  batch_sig: string;
+  created_at: number;
+  expires_at: number;
+}
+
+/** Wire shape of the LNURL-pay callback (snake_case `proof`). */
+export interface LspLnurlpCallbackWire {
+  pr: string;
+  routes?: unknown[];
+  status?: string;
+  reason?: string;
+  proof?: LspApayInvoiceProofWire;
+}
+
+/** Wire shape of `GET /lightning_address/by_pubkey/{pubkey}` (snake_case). */
+export interface LspLightningAddressByPubkeyWire {
+  username: string;
+  domain: string;
+  recipient_pubkey?: string;
+  address_sig?: string;
+}
+
 export interface LspLnurlpCallbackResponse {
   pr: string;
   routes: unknown[];
   status?: string;
   reason?: string;
+  /**
+   * APay hash-substitution-resistance proof (utexo-lsp >= 0.6 / PR #22).
+   * Present when the address was registered with an attestation
+   * (see {@link IUtexoLSPClient} / apayNewWithAddress). Lets the payer verify
+   * the payment hash is committed under the recipient's signed batch root
+   * before paying. Optional — older LSPs omit it.
+   */
+  proof?: ApayInvoiceProof;
+}
+
+/** One step of the APay Merkle inclusion proof. */
+export interface ApayMerkleProofElement {
+  sibling: string;
+  /** 'left' | 'right' — which side the sibling is on. */
+  side: string;
+}
+
+/** utexo-lsp APay invoice proof (LNURL callback `proof` field). */
+export interface ApayInvoiceProof {
+  version: number;
+  recipientPubkey: string;
+  hostPubkey: string;
+  batchId: string;
+  hashIndex: number;
+  paymentHash: string;
+  batchRoot: string;
+  batchSize: number;
+  merkleProof: ApayMerkleProofElement[];
+  batchSig: string;
+  createdAt: number;
+  expiresAt: number;
 }
 
 /** utexo-lsp `GET /lightning_address/by_pubkey/{pubkey}` */
 export interface LspLightningAddressByPubkeyResponse {
   username: string;
   domain: string;
+  /** Recipient node pubkey — present on utexo-lsp >= 0.6 (PR #22). */
+  recipientPubkey?: string;
+  /** Address-ownership attestation signature — present once registered via apayNewWithAddress. */
+  addressSig?: string;
 }
 
 // ── LspPeer ───────────────────────────────────────────────────────────────────

--- a/src/wallet/network-defaults.ts
+++ b/src/wallet/network-defaults.ts
@@ -19,6 +19,39 @@ const RLN_NETWORK_OVERRIDES: Partial<Record<string, Partial<NetworkEndpoints>>> 
   signet: { proxyEndpoint: 'rpcs://rgb-proxy.utexo.com/json-rpc' },
 };
 
+/**
+ * Default utexo-lsp HTTP base URLs per network. Used when the caller omits
+ * lspBaseUrl in the wallet params so LSP-backed flows work out of the box.
+ * Networks without an entry have no default and must be configured explicitly.
+ */
+const DEFAULT_LSP_BASE_URLS: Partial<Record<string, string>> = {
+  utexo: 'https://lsp-signet.utexo.com',
+};
+
+/** Returns the default lspBaseUrl for a network, or undefined if none exists. */
+export function getDefaultLspBaseUrl(network: string): string | undefined {
+  return DEFAULT_LSP_BASE_URLS[network];
+}
+
+/**
+ * Resolves the lspBaseUrl to use: the explicit value if provided, otherwise the
+ * per-network default. Throws when neither is available so callers fail loudly
+ * instead of silently hitting a missing LSP.
+ */
+export function resolveLspBaseUrl(
+  network: string,
+  lspBaseUrl?: string | null
+): string {
+  const resolved = lspBaseUrl ?? DEFAULT_LSP_BASE_URLS[network];
+  if (!resolved) {
+    throw new Error(
+      `No lspBaseUrl configured for network "${network}" and no default is available. ` +
+        'Set lspBaseUrl in the wallet params or pass an explicit LspPeer to createLsp().'
+    );
+  }
+  return resolved;
+}
+
 export function getNetworkDefaults(network: string): NetworkEndpoints | undefined {
   const indexerUrl = DEFAULT_INDEXER_URLS[network as Network];
   const proxyEndpoint = DEFAULT_TRANSPORT_ENDPOINTS[network as Network];

--- a/src/wallet/rln-manager.ts
+++ b/src/wallet/rln-manager.ts
@@ -218,6 +218,14 @@ export class RLNManager implements IRLN {
     return this.rlnBinding.rlnApayNew(hostNodeId);
   }
 
+  rlnApayNewWithAddress(
+    hostNodeId: string,
+    username: string,
+    domain: string
+  ): Promise<RlnApayNewResponse> {
+    return this.rlnBinding.rlnApayNewWithAddress(hostNodeId, username, domain);
+  }
+
   rlnDecodeLnInvoice(invoice: string): Promise<RlnDecodeLnInvoiceResponse> {
     return this.rlnBinding.rlnDecodeLnInvoice(invoice);
   }

--- a/src/wallet/utexo-wallet.ts
+++ b/src/wallet/utexo-wallet.ts
@@ -61,7 +61,7 @@ import { RLNManager, createRLNManager } from './rln-manager';
 import type { IRLNSigner } from './rln-signers';
 import type { IRLNUnlockParams, IRLNNodeCreateParams } from '../binding/IRLN';
 import { toNativeNetwork } from '../binding/Interfaces';
-import { resolveUnlockParams } from './network-defaults';
+import { getDefaultLspBaseUrl, resolveLspBaseUrl, resolveUnlockParams } from './network-defaults';
 import type {
   RlnNodeInfo,
   RlnNetworkInfo,
@@ -390,6 +390,8 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
   private readonly params: UTEXOWalletNodeParams;
   private readonly signer: IRLNSigner;
   private disposed = false;
+  /** True once rlnCreateNode has run (init/reinit). Virtual-channel params are baked then. */
+  private nodeCreated = false;
 
   constructor(params: UTEXOWalletNodeParams, signer: IRLNSigner) {
     this.params = params;
@@ -402,6 +404,7 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
   /** First-time init: createNode + signer.initNode (writes keys to disk). */
   async init(): Promise<void> {
     await this.rln.rlnCreateNode(this.buildNodeParams());
+    this.nodeCreated = true;
     await this.signer.initNode(this.rln);
   }
 
@@ -418,6 +421,7 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
   async reinit(params?: IRLNUnlockParams): Promise<void> {
     this.rln = createRLNManager();
     await this.rln.rlnCreateNode(this.buildNodeParams());
+    this.nodeCreated = true;
     if (params) await this.signer.unlockNode(this.rln, resolveUnlockParams(this.params.network, params));
   }
 
@@ -853,12 +857,12 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
   async createLsp(peer?: LspPeer, peerPort = 9735): Promise<UtexoLsp> {
     if (peer) return new UtexoLsp(this, peer);
 
-    const baseUrl = this.params.lspBaseUrl;
-    if (!baseUrl) throw new Error('createLsp: lspBaseUrl not set — pass a LspPeer explicitly or set lspBaseUrl in wallet params');
+    const baseUrl = resolveLspBaseUrl(this.params.network, this.params.lspBaseUrl);
 
     const http     = new UtexoLSPClient({ baseUrl, bearerToken: this.params.lspBearerToken ?? undefined });
     const info     = await http.getInfo();
     const peerHost = new URL(baseUrl).hostname;
+    this.enableVirtualChannelsForPeer(info.pubkey);
 
     return new UtexoLsp(this, {
       baseUrl,
@@ -867,6 +871,28 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
       peerPort,
       bearerToken: this.params.lspBearerToken ?? undefined,
     });
+  }
+
+  /**
+   * Turns on virtual channels v0 for the given LSP peer by mutating the node-create params.
+   *
+   * These params (enableVirtualChannelsV0, virtualPeerPubkeys) are consumed by rlnCreateNode
+   * and cannot be changed after the node exists, so this must run before init()/reinit().
+   * Throws if the node was already created.
+   */
+  private enableVirtualChannelsForPeer(peerPubkey: string): void {
+    if (this.nodeCreated) {
+      throw new Error(
+        'createLsp() must be called before init()/reinit(): virtual-channel params ' +
+          '(enableVirtualChannelsV0, virtualPeerPubkeys) are baked into the node at init time ' +
+          'and cannot be changed afterwards.',
+      );
+    }
+    this.params.enableVirtualChannelsV0 = true;
+    const existing = this.params.virtualPeerPubkeys ?? [];
+    this.params.virtualPeerPubkeys = existing.includes(peerPubkey)
+      ? existing
+      : [...existing, peerPubkey];
   }
 
   /**
@@ -1098,7 +1124,7 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
       vssUrl: this.params.vssUrl ?? null,
       vssAllowHttp: this.params.vssAllowHttp ?? false,
       vssAllowEmptyRestore: this.params.vssAllowEmptyRestore ?? false,
-      lspBaseUrl: this.params.lspBaseUrl ?? null,
+      lspBaseUrl: this.params.lspBaseUrl ?? getDefaultLspBaseUrl(this.params.network) ?? null,
       lspBearerToken: this.params.lspBearerToken ?? null,
     };
   }

--- a/src/wallet/utexo-wallet.ts
+++ b/src/wallet/utexo-wallet.ts
@@ -805,6 +805,39 @@ export class UTEXOWallet implements IWalletManager, IUTEXOProtocol {
     };
   }
 
+  /**
+   * Register an async-payment hash pool bound to a Lightning Address.
+   *
+   * Same as {@link apayNew} but additionally signs an address attestation
+   * (username + domain) so the LSP can prove the address is owned by this node
+   * — required for APay hash-substitution resistance.
+   */
+  async apayNewWithAddress(
+    hostNodeId: string,
+    username: string,
+    domain: string
+  ): Promise<ApayNewResponse> {
+    const raw = await this.rln.rlnApayNewWithAddress(
+      hostNodeId,
+      username,
+      domain
+    );
+    return {
+      requestId: raw.requestId,
+      hostNodeId: raw.hostNodeId,
+      protocolVersion: raw.protocolVersion,
+      orderId: raw.orderId,
+      status: raw.status,
+      acceptedThroughIndex: raw.acceptedThroughIndex,
+      nextIndexExpected: raw.nextIndexExpected,
+      unusedHashes: raw.unusedHashes,
+      refillBatchSize: raw.refillBatchSize,
+      firstHashIndex: raw.firstHashIndex,
+      lastHashIndex: raw.lastHashIndex,
+      hashes: raw.hashes,
+    };
+  }
+
   // ── LSP ──────────────────────────────────────────────────────────────────────
 
   /**


### PR DESCRIPTION
__added__
- **`apayNewWithAddress(hostNodeId, username, domain)`** on `UTEXOWallet` — registers an async-payment hash pool together with a Lightning Address attestation (`address_sig`). Required for APay hash-substitution resistance; works with password and external signers. Native bridge: `rlnApayNewWithAddress` on iOS and Android.
- **`UtexoLsp.refillHashPool()`** — tops up the APay hash pool with a fresh attested batch when `unusedHashes` runs low.
- **`ApayInvoiceProof`** / **`ApayMerkleProofElement`** types — Merkle proof returned on LNURL-pay callbacks so payers can verify the payment hash before paying.
- Per-network default `lspBaseUrl` — `network: 'utexo'` resolves to `https://lsp-signet.utexo.com` when `lspBaseUrl` is omitted. Helpers in `src/wallet/network-defaults.ts`: `getDefaultLspBaseUrl(network)` and `resolveLspBaseUrl(network, lspBaseUrl?)` (throws when neither an explicit value nor a network default exists).

__changed__
- **`UtexoLsp.enableLightningAddress()`** — now polls the LSP for a provisioned username/domain (`getLightningAddressByPubkey`), then registers a single attested batch via `apayNewWithAddress` (no bootstrap `apayNew` first — avoids `invalid_hash_batch` overflow). Returns `unusedHashes`, `nextIndexExpected`, and `refillBatchSize` from the pool response.
- **`createLsp()`** — auto-wires virtual channels: fetches the LSP pubkey (`GET /get_info`), sets `enableVirtualChannelsV0: true`, and adds that pubkey to `virtualPeerPubkeys`. Callers no longer need to fetch the LSP pubkey manually for LSP-backed virtual channels.
- **`UtexoLSPClient`** — explicit snake_case wire mapping for `getLightningAddressByPubkey` (`recipient_pubkey`, `address_sig`) and LNURL-pay callbacks (`proof` → `ApayInvoiceProof`). Fixes fields that were `undefined` against utexo-lsp >= 0.6.
- Bumped RLN native bindings to **v0.6.0-beta.2** (from `0.6.0-beta.1`).

__breaking__
- **`createLsp()` must be called before `init()`/`reinit()`** — virtual-channel params are baked into the node at init time. Calling `createLsp()` after the node exists throws. Update any `init() → createLsp()` ordering to `createLsp() → init()`.
