### PR TITLE
feat: bump RLN bindings to v0.10.0-beta.3 and surface real native error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.0-beta.26
 
 __changed__
 - Bumped RLN native bindings to **v0.10.0-beta.3** (from `0.9.0-beta.3`). The only binding API change is a new `RlnError.FailedVssInit` variant, so no call sites moved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+__changed__
+- Bumped RLN native bindings to **v0.10.0-beta.3** (from `0.9.0-beta.3`). The only binding API change is a new `RlnError.FailedVssInit` variant, so no call sites moved.
+- **Native errors now carry the real reason instead of a generic category message.** Previously every node-state conflict surfaced as `"conflict with current node state"`, no matter whether the wallet already had enough UTXOs, the node was already initialized, fees could not be estimated, or the network did not match. The `RlnError` variants now carry the underlying `APIError` display string, so the rejection reaching JS has the actual message (e.g. `"wallet has enough allocations available"`) while `error.code` keeps the category (`Conflict`, `NotFound`, `InsufficientFunds`, …). Note the category is still coarse — `AllocationsAlreadyAvailable`, `NetworkMismatch`, `CannotEstimateFees` and friends all remain `Conflict`, distinguishable only by message.
+- **iOS `errorCode` is now the error category, not `"RlnError"`.** `RgbSwiftHelper` derived the code from the Swift type name, which for a UniFFI enum is just the enum itself, so every RLN failure reached JS as `code: "RlnError"`. It now reports the case name, matching what Android already reported.
+
+__fixed__
+- Conflict-retry paths (`rlnInitNode`, `rlnUnlockNode`, `rlnUnlockNodeWithExternalSigner`) no longer depend on the word "conflict" appearing in the message. With the richer messages from `0.10.0-beta.3` the old text match would have stopped firing, silently dropping the init/unlock retry on both platforms; detection now keys off the error category.
+
+---
+
 ## 1.0.0-beta.25
 
 __added__

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,9 +92,9 @@ The signer is created with a disk-backed VLS store (`NativeExternalSigner.newWit
 
 **iOS**: `Rgb.mm` (ObjC++ bridge) dispatches to `RgbSwiftHelper.swift` synchronous static methods, returning NSDictionary results. The `.mm` file bridges async Promise calls into those sync helpers via Grand Central Dispatch.
 
-**Android**: `RgbModule.kt` extends the codegen-generated `NativeRgbSpec`, dispatches each bridge call via Kotlin coroutines (`Dispatchers.IO`). The Android binding (`com.utexo:rgb-lightning-node-android:0.9.0-beta.3`) is resolved from Maven Central. JNA (`net.java.dev.jna:jna:5.17.0@aar`) is required for UniFFI.
+**Android**: `RgbModule.kt` extends the codegen-generated `NativeRgbSpec`, dispatches each bridge call via Kotlin coroutines (`Dispatchers.IO`). The Android binding (`com.utexo:rgb-lightning-node-android:0.10.0-beta.3`) is resolved from Maven Central. JNA (`net.java.dev.jna:jna:5.17.0@aar`) is required for UniFFI.
 
-**iOS native framework**: `RGBLightningNode.xcframework` is downloaded from GitHub releases during `postinstall` (`scripts/download-rln-bindings.js`). It is not committed. Version is pinned at `0.9.0-beta.3`. For local development with a custom build, place `swift-release.zip` at `src/bindings/swift-release.zip` — the script will use it instead.
+**iOS native framework**: `RGBLightningNode.xcframework` is downloaded from GitHub releases during `postinstall` (`scripts/download-rln-bindings.js`). It is not committed. Version is pinned at `0.10.0-beta.3`. For local development with a custom build, place `swift-release.zip` at `src/bindings/swift-release.zip` — the script will use it instead.
 
 ### Type mapping
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,7 +75,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation("com.utexo:rgb-lightning-node-android:0.9.0-beta.3")
+  implementation("com.utexo:rgb-lightning-node-android:0.10.0-beta.3")
   // UniFFI-generated RLN Kotlin bindings require JNA. Use Android AAR artifact
   // explicitly to avoid Gradle resolving both .aar and .jar variants.
   implementation "net.java.dev.jna:jna:5.17.0@aar"

--- a/android/src/main/java/com/rgbsdkrn/RgbModule.kt
+++ b/android/src/main/java/com/rgbsdkrn/RgbModule.kt
@@ -22,6 +22,7 @@ import org.utexo.rgblightningnode.SdkInitRequest
 import org.utexo.rgblightningnode.SdkKeysendRequest
 import org.utexo.rgblightningnode.LnInvoiceRequest
 import org.utexo.rgblightningnode.NativeExternalSigner
+import org.utexo.rgblightningnode.RlnException
 import org.utexo.rgblightningnode.SdkExternalSignerBootstrap
 import org.utexo.rgblightningnode.SdkNode
 import org.utexo.rgblightningnode.SdkOpenChannelRequest
@@ -1892,6 +1893,10 @@ class RgbModule(reactContext: ReactApplicationContext) :
   }
 
   private fun isConflictLike(error: Throwable): Boolean {
+    // Since RLN 0.10.0-beta.3 the exception message carries the real reason
+    // (e.g. "wallet has enough allocations available") instead of the generic
+    // "conflict with current node state", so match the variant class first.
+    if (error is RlnException.Conflict) return true
     val loweredMessage = (error.message ?: "").lowercase()
     return loweredMessage.contains("conflict")
   }

--- a/ios/RGBLightningNode.swift
+++ b/ios/RGBLightningNode.swift
@@ -8758,6 +8758,8 @@ public enum RlnError {
 
     case UnsupportedInExternalSignerMode(message: String)
 
+    case FailedVssInit(message: String)
+
     case Internal(message: String)
 }
 
@@ -8838,7 +8840,11 @@ public struct FfiConverterTypeRlnError: FfiConverterRustBuffer {
                 message: FfiConverterString.read(from: &buf)
             )
 
-        case 18: return try .Internal(
+        case 18: return try .FailedVssInit(
+                message: FfiConverterString.read(from: &buf)
+            )
+
+        case 19: return try .Internal(
                 message: FfiConverterString.read(from: &buf)
             )
 
@@ -8882,8 +8888,10 @@ public struct FfiConverterTypeRlnError: FfiConverterRustBuffer {
             writeInt(&buf, Int32(16))
         case .UnsupportedInExternalSignerMode(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(17))
-        case .Internal(_ /* message is ignored*/ ):
+        case .FailedVssInit(_ /* message is ignored*/ ):
             writeInt(&buf, Int32(18))
+        case .Internal(_ /* message is ignored*/ ):
+            writeInt(&buf, Int32(19))
         }
     }
 }

--- a/ios/RgbSwiftHelper.swift
+++ b/ios/RgbSwiftHelper.swift
@@ -5,11 +5,34 @@ import Foundation
 public class RgbSwiftHelper: NSObject {
 
   private static func getErrorClassName(_ error: Error) -> String {
+    // UniFFI errors are Swift enums (`RlnError.Conflict(message:)`), so
+    // `type(of:)` only yields the enum name and loses the category the JS layer
+    // matches on. Recover the case name from the description when possible —
+    // Kotlin reports the nested class name (`Conflict`) for the same error.
+    if let caseName = uniffiErrorCaseName(error) {
+      return caseName
+    }
     let errorType = String(describing: type(of: error))
     if let dotIndex = errorType.lastIndex(of: ".") {
       return String(errorType[errorType.index(after: dotIndex)...])
     }
     return errorType
+  }
+
+  /// Extracts `Conflict` from `Conflict(message: "…")`. Returns nil for
+  /// anything that isn't a bare enum case with associated values.
+  private static func uniffiErrorCaseName(_ error: Error) -> String? {
+    let described = String(describing: error)
+    guard let paren = described.firstIndex(of: "(") else { return nil }
+    let name = String(described[described.startIndex..<paren])
+    guard !name.isEmpty, name.count <= 64 else { return nil }
+    guard let first = name.first, first.isLetter || first == "_" else {
+      return nil
+    }
+    guard name.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) else {
+      return nil
+    }
+    return name
   }
 
   private static func parseErrorMessage(_ error: Error) -> String {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
-    "@utexo/rgb-sdk-core": "1.0.0-beta.5"
+    "@utexo/rgb-sdk-core": "1.0.0-beta.6"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/scripts/download-rln-bindings.js
+++ b/scripts/download-rln-bindings.js
@@ -7,7 +7,7 @@ const { execSync } = require('child_process');
 // or used from a local zip in src/bindings/ if present.
 // Android AAR is resolved from Maven Central by Gradle — no download needed here.
 
-const VERSION = '0.9.0-beta.3';
+const VERSION = '0.10.0-beta.3';
 const BASE_URL = `https://github.com/UTEXO-Protocol/rgb-lightning-node/releases/download/v${VERSION}`;
 
 const ROOT = path.join(__dirname, '..');

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ export type {
   SendAssetResult,
   PayAddressOptions,
   LightningAddressInfo,
+  ParsedLightningAddress,
   ClaimResult,
 } from '@utexo/rgb-sdk-core';
 
@@ -113,6 +114,12 @@ export {
   isNetwork,
   toUnitsNumber,
   fromUnitsNumber,
+  // Lightning Address / UMA (`$user@host`) helpers
+  isUmaAddress,
+  normalizeLightningAddress,
+  parseLightningAddress,
+  UMA_PREFIX,
+  UMA_MAX_USERNAME_LENGTH,
   // UTEXO network config
   DEFAULT_TRANSPORT_ENDPOINTS,
   DEFAULT_INDEXER_URLS,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,10 +1636,10 @@
     "@typescript-eslint/types" "8.55.0"
     eslint-visitor-keys "^4.2.1"
 
-"@utexo/rgb-sdk-core@1.0.0-beta.5":
-  version "1.0.0-beta.5"
-  resolved "https://registry.npmjs.org/@utexo/rgb-sdk-core/-/rgb-sdk-core-1.0.0-beta.5.tgz"
-  integrity sha512-YzgNuXg6knHcsGBjSCHbx/Eu4C1IZp8lYfj3iUlgy4c0n5Eyd9gDP+6cYwlfzDIqsDSdcIy9ELoDRgQdoG2/jA==
+"@utexo/rgb-sdk-core@1.0.0-beta.6":
+  version "1.0.0-beta.6"
+  resolved "https://registry.npmjs.org/@utexo/rgb-sdk-core/-/rgb-sdk-core-1.0.0-beta.6.tgz"
+  integrity sha512-ver6hvOejKjjWviDaWuyb/FxKXPq/yu/tvFqvDADBa0sAPA6CBmOEJy3872Kq70FMqrJbrUBxvVz+rPTOohWGQ==
   dependencies:
     "@noble/hashes" "^2.0.1"
     "@noble/secp256k1" "3.0.0"


### PR DESCRIPTION
## 1.0.0-beta.26

__changed__
- Bumped RLN native bindings to **v0.10.0-beta.3** (from `0.9.0-beta.3`). The only binding API change is a new `RlnError.FailedVssInit` variant, so no call sites moved.
- **Native errors now carry the real reason instead of a generic category message.** Previously every node-state conflict surfaced as `"conflict with current node state"`, no matter whether the wallet already had enough UTXOs, the node was already initialized, fees could not be estimated, or the network did not match. The `RlnError` variants now carry the underlying `APIError` display string, so the rejection reaching JS has the actual message (e.g. `"wallet has enough allocations available"`) while `error.code` keeps the category (`Conflict`, `NotFound`, `InsufficientFunds`, …). Note the category is still coarse — `AllocationsAlreadyAvailable`, `NetworkMismatch`, `CannotEstimateFees` and friends all remain `Conflict`, distinguishable only by message.
- **iOS `errorCode` is now the error category, not `"RlnError"`.** `RgbSwiftHelper` derived the code from the Swift type name, which for a UniFFI enum is just the enum itself, so every RLN failure reached JS as `code: "RlnError"`. It now reports the case name, matching what Android already reported.

__fixed__
- Conflict-retry paths (`rlnInitNode`, `rlnUnlockNode`, `rlnUnlockNodeWithExternalSigner`) no longer depend on the word "conflict" appearing in the message. With the richer messages from `0.10.0-beta.3` the old text match would have stopped firing, silently dropping the init/unlock retry on both platforms; detection now keys off the error category.

---