### PR TITLE
Feat/lsp ifa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-beta.27
+
+__changed__
+- Bumped `@utexo/rgb-sdk-core` to **1.0.0-beta.7**. `LspGetInfoResponse` gains optional `host`/`port` fields (P2P address, additive-only contract).
+- **`createLsp()` no-arg form now discovers peer host and port from `GET /get_info`** instead of taking the hostname from `lspBaseUrl` and defaulting the port to `9735`. Falls back to the HTTP hostname and the `peerPort` argument only when the LSP publishes no address.
+
 ## 1.0.0-beta.26
 
 __changed__

--- a/docs/async-payments.md
+++ b/docs/async-payments.md
@@ -114,7 +114,7 @@ const wallet = new UTEXOWallet({
   lspBearerToken: 'bearer-token',
 }, signer);
 
-// createLsp() before init(): discovers pubkey/host from lspBaseUrl + GET /get_info
+// createLsp() before init(): discovers pubkey, host and port from GET /get_info
 // and auto-wires virtual channels into the node params.
 const lsp = await wallet.createLsp();
 
@@ -132,7 +132,8 @@ const wallet = new UTEXOWallet({
   virtualPeerPubkeys:      [lspPeerPubkey],  // fetch once from GET /get_info
 }, signer);
 
-const lsp = await wallet.createLsp(undefined, 9737);  // regtest LDK port ≠ default 9735
+// The port argument is only a fallback for an LSP that publishes no address.
+const lsp = await wallet.createLsp(undefined, 9737);
 ```
 
 Explicit `LspPeer` + `createLsp(LSP_PEER)` is still valid when you cannot set `lspBaseUrl` on the wallet (e.g. Android emulator host override).

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -21,7 +21,7 @@ const wallet = new UTEXOWallet({
   lspBearerToken: 'bearer-token',  // only required for APay
 }, signer);
 
-// No-arg: peer pubkey from GET /get_info, host from lspBaseUrl, port 9735.
+// No-arg: peer pubkey, host and port all from GET /get_info.
 // MUST be called before init() — it auto-wires virtual channels into node params.
 const lsp = await wallet.createLsp();
 
@@ -425,7 +425,9 @@ SDK: `lsp.sendAsset()`
 ```typescript
 // Get LSP info
 const info = await lsp.http.getInfo();
-console.log(info.pubkey, info.numUsableChannels);
+console.log(`${info.pubkey}@${info.host}:${info.port}`, info.network);
+// Amounts are bigint — the wire sends u64 as strings.
+console.log(info.minPaymentSizeMsat, info.supportedAssets[0]?.schema);
 
 // Resolve a Lightning Address (LNURL discovery)
 const { pr } = await lsp.http.resolveAddress('alice@lsp-signet.utexo.com', 3_000_000);

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@scure/bip32": "^2.0.1",
     "@scure/bip39": "^2.0.1",
     "@scure/btc-signer": "^2.0.1",
-    "@utexo/rgb-sdk-core": "1.0.0-beta.6"
+    "@utexo/rgb-sdk-core": "1.0.0-beta.7"
   },
   "react-native-builder-bob": {
     "source": "src",

--- a/src/wallet/utexo-wallet.ts
+++ b/src/wallet/utexo-wallet.ts
@@ -879,7 +879,10 @@ export class UTEXOWallet implements IUTEXOProtocol<IRLNUnlockParams> {
    *
    * No-arg form — auto-discovers peer info from the wallet's lspBaseUrl:
    *   const lsp = await wallet.createLsp();
-   *   // pubkey from GET /get_info, host from lspBaseUrl, port defaults to 9735
+   *   // pubkey, host and port all from GET /get_info
+   *
+   * An LSP that publishes no address falls back to the HTTP hostname and the
+   * `peerPort` argument.
    *
    * Explicit form — use when you already have the peer details:
    *   const lsp = await wallet.createLsp({ baseUrl, peerPubkey, peerHost, peerPort });
@@ -897,14 +900,13 @@ export class UTEXOWallet implements IUTEXOProtocol<IRLNUnlockParams> {
       bearerToken: this.params.lspBearerToken ?? undefined,
     });
     const info = await http.getInfo();
-    const peerHost = new URL(baseUrl).hostname;
     this.enableVirtualChannelsForPeer(info.pubkey);
 
     return new UtexoLsp(this, {
       baseUrl,
       peerPubkey: info.pubkey,
-      peerHost,
-      peerPort,
+      peerHost: info.host ?? new URL(baseUrl).hostname,
+      peerPort: info.port ?? peerPort,
       bearerToken: this.params.lspBearerToken ?? undefined,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1636,10 +1636,10 @@
     "@typescript-eslint/types" "8.55.0"
     eslint-visitor-keys "^4.2.1"
 
-"@utexo/rgb-sdk-core@1.0.0-beta.6":
-  version "1.0.0-beta.6"
-  resolved "https://registry.npmjs.org/@utexo/rgb-sdk-core/-/rgb-sdk-core-1.0.0-beta.6.tgz"
-  integrity sha512-ver6hvOejKjjWviDaWuyb/FxKXPq/yu/tvFqvDADBa0sAPA6CBmOEJy3872Kq70FMqrJbrUBxvVz+rPTOohWGQ==
+"@utexo/rgb-sdk-core@1.0.0-beta.7":
+  version "1.0.0-beta.7"
+  resolved "https://registry.npmjs.org/@utexo/rgb-sdk-core/-/rgb-sdk-core-1.0.0-beta.7.tgz"
+  integrity sha512-QsbhuWTqFU++IaGsE9Ls3oNbxl9sNJtpiidlw6ODItDadyQDFrGiUFUQe3bkno7fF0S5HqkGKOQIqKI0/EadMw==
   dependencies:
     "@noble/hashes" "^2.0.1"
     "@noble/secp256k1" "3.0.0"


### PR DESCRIPTION

## 1.0.0-beta.27

__changed__
- Bumped `@utexo/rgb-sdk-core` to **1.0.0-beta.7**. `LspGetInfoResponse` gains optional `host`/`port` fields (P2P address, additive-only contract).
- **`createLsp()` no-arg form now discovers peer host and port from `GET /get_info`** instead of taking the hostname from `lspBaseUrl` and defaulting the port to `9735`. Falls back to the HTTP hostname and the `peerPort` argument only when the LSP publishes no address.