### PR TITLE
chore: add AI code review (Claude + Kimi)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,62 @@
+name: AI Review - Claude
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review (for manual reruns)"
+        required: true
+        type: string
+
+jobs:
+  claude-review:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' &&
+       (github.event.label.name == 'ai-review/claude' || github.event.label.name == 'claude-review')) ||
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' &&
+       (contains(github.event.pull_request.labels.*.name, 'ai-review/claude') || contains(github.event.pull_request.labels.*.name, 'claude-review'))) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ai-review-claude-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          show_full_output: false
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+
+            Please review this pull request and provide feedback on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Performance considerations
+            - Security concerns
+            - Test coverage
+
+            Use the repository's CLAUDE.md for guidance on style and conventions.
+            Be constructive and helpful in your feedback.
+
+            Use `gh pr comment` to publish your final review on the PR.
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/kimi-code-review.yml
+++ b/.github/workflows/kimi-code-review.yml
@@ -1,0 +1,47 @@
+name: AI Review - Kimi
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number to review (for manual reruns)"
+        required: true
+        type: string
+
+jobs:
+  kimi-review:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.action == 'labeled' &&
+       github.event.label.name == 'ai-review/kimi') ||
+      (github.event_name == 'pull_request' && github.event.action == 'synchronize' &&
+       contains(github.event.pull_request.labels.*.name, 'ai-review/kimi')) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '@kimi'))
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ai-review-kimi-pr-${{ github.event_name == 'workflow_dispatch' && inputs.pr_number || github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Run Kimi Code Review
+        uses: UTEXO-Protocol/kimi-actions@main
+        with:
+          kimi_api_key: ${{ secrets.KIMI_API_KEY }}
+          kimi_base_url: https://api.moonshot.ai/v1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model: kimi-k2.6
+          language: en-US
+          review_level: normal
+          pr_number: ${{ inputs.pr_number }}

--- a/.github/workflows/kimi-code-review.yml
+++ b/.github/workflows/kimi-code-review.yml
@@ -41,7 +41,7 @@ jobs:
           kimi_api_key: ${{ secrets.KIMI_API_KEY }}
           kimi_base_url: https://api.moonshot.ai/v1
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          model: kimi-k2.6
+          model: kimi-k3
           language: en-US
           review_level: normal
           pr_number: ${{ inputs.pr_number }}

--- a/.kimi-config.yml
+++ b/.kimi-config.yml
@@ -1,0 +1,8 @@
+categories:
+  bug: true
+  performance: true
+  security: true
+
+extra_instructions: |
+  Before starting the review, read the CLAUDE.md file in the root of this repository.
+  Use it as the primary guide for project conventions, code style, and review priorities.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,100 @@ The TurboModule spec is `src/binding/NativeRgb.ts` (module name `'Rgb'`, package
 
 The `lib/` directory and native binary artifacts (`ios/RGBLightningNode.xcframework`, `android/src/main/jniLibs/`) are excluded from git and must be built/downloaded locally.
 
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Language | TypeScript 5, strict mode |
+| Output | ESM (`lib/module/`) + type declarations (`lib/typescript/`) |
+| Build | react-native-builder-bob |
+| Native bridge | TurboModules + Codegen (React Native new architecture) |
+| iOS native | `RGBLightningNode.xcframework` (downloaded via postinstall) |
+| Android native | `com.utexo:rgb-lightning-node-android` from Maven Central + JNA |
+| Crypto | `@noble/*` + `@scure/*` (via `@utexo/rgb-sdk-core`) |
+| Linting | ESLint + Prettier |
+| Package manager | yarn |
+
+## Project Structure
+
+```
+src/
+  index.ts                      Public entry — re-exports core surface + RN-specific
+  binding/
+    NativeRgb.ts                TurboModule spec (module name 'Rgb', package com.rgbsdkrn)
+    RLNBinding.ts               Sequential call queue (withNodeQueue), lifecycle state machine,
+                                normalizeBtcBalance parser
+    rln-types.ts                Raw Wire types as returned by native layer (Rln* prefix)
+  wallet/
+    utexo-wallet.ts             UTEXOWallet — public API, implements IUTEXOProtocol,
+                                owns map* converters (Wire → domain types)
+    rln-manager.ts              RLNManager — thin facade over RLNBinding
+    rln-signers.ts              PasswordRLNSigner, NativeExternalRLNSigner (IRLNSigner)
+  scripts/
+    download-rln-bindings.js    Downloads iOS xcframework from GitHub releases
+    setup-rln-bindings.js       Installs xcframework into ios/
+android/
+  src/main/java/com/rgbsdkrn/
+    RgbModule.kt                NativeRgbSpec impl, dispatches via Dispatchers.IO
+    RlnNodeStore.kt             Integer-keyed registry of live SdkNode instances
+ios/
+  Rgb.mm                        ObjC++ bridge → RgbSwiftHelper.swift (sync static methods)
+  RgbSwiftHelper.swift          Swift wrappers around RGBLightningNode.xcframework
+  RlnNodeStore.swift            Integer-keyed registry of live SdkNode instances
+```
+
+## Code Conventions
+
+**TypeScript**
+- `strict: true`, `import type` for type-only imports, no `any` in status/amount code paths.
+- Errors extend base classes from `@utexo/rgb-sdk-core`; call `Object.setPrototypeOf(this, new.target.prototype)` in constructors.
+
+**Naming**
+- `Rln*` prefix — raw types from the native layer (Wire types).
+- `map*` — converter functions from `Rln*` Wire types to `@utexo/rgb-sdk-core` domain types; live in `utexo-wallet.ts`.
+- `I*` — interfaces.
+- `normalize*` — throws on invalid input; `tryNormalize*` — returns `undefined`.
+
+**Node queue discipline** — all native calls must go through `withNodeQueue()` in `RLNBinding`. Never call native methods directly from `UTEXOWallet` or `RLNManager`. Queue ensures serial execution and blocks non-lifecycle calls during shutdown/destroy.
+
+**Enum normalization** — Android returns `SCREAMING_SNAKE_CASE`, iOS returns `lowerCamelCase`. Always pass raw native enum values through `canonicalEnum()` before use. Never hard-code platform-specific enum strings outside the normalizer.
+
+**Null vs undefined at bridge boundary** — native layer returns `null` for missing values; TypeScript surface uses `undefined`. `map*` functions must convert `null → undefined` explicitly.
+
+**Type mappers** — `map*` functions in `utexo-wallet.ts` must strip all `Rln*`-prefixed keys before returning domain objects. No Wire keys must leak into the public surface.
+
+**Adding a new native method**:
+1. Add to `NativeRgb.ts` spec
+2. Run `yarn codegen`
+3. Implement in `RgbModule.kt` (Android) and `RgbSwiftHelper.swift` + `Rgb.mm` (iOS)
+4. Add wrapper in `RLNBinding.ts` (through `withNodeQueue`)
+5. Expose via `RLNManager.ts` and `UTEXOWallet`/`IUTEXOProtocol` if public
+
+## Code Review Focus Areas
+
+### Security
+
+- **Seed/key material in memory**: `NativeExternalRLNSigner` holds seed hex to support cold-start re-derivation. Any change that logs, serializes, or exposes this value is a critical security bug.
+- **`vssAllowHttp` defaults**: VSS over HTTP must default to `false`. PRs that change this default or make it opt-out rather than opt-in require security review.
+- **`permissivePolicy` flag**: must not be set to `true` in production configs. Flag bypasses signer validation — review any PR that changes its default or passes it from external input.
+- **`lspBearerToken` leakage**: must not appear in logs, error messages, or responses. Check all new logging statements in LSP flow paths.
+- **TurboModule positional parameters**: codegen does not validate parameter names at runtime — only positions. A wrong parameter order passes TypeScript checking but silently sends wrong values to native. Review any reordering in `NativeRgb.ts`.
+
+### Correctness
+
+- **Node ID lifecycle**: `rlnNodeId` is assigned by native on `rlnCreateNode` and released on `rlnDestroyNode`. Any code path that reuses a stale `rlnNodeId` after destroy will corrupt the native registry.
+- **Queue deadlock risk**: calls inside `withNodeQueue` must not await another `withNodeQueue` call. Nested queue entries deadlock.
+- **Enum normalization gaps**: `canonicalEnum()` only normalizes known enum shapes. New enum types from the native layer must be added to the normalizer — otherwise they fall through as raw strings.
+- **Timestamp units**: RLN returns some timestamps in seconds, others in milliseconds. Check the unit of each new timestamp field — confusing them causes display and comparison bugs.
+- **Amount precision**: amounts that exceed `Number.MAX_SAFE_INTEGER` must use `bigint`. Any `Number()` conversion of a u64 amount field is a bug.
+- **Transfer status fallbacks**: `mapTransfer` must not silently default an unknown status to a valid status. Unknown statuses must either throw or propagate as a typed unknown variant.
+
+### Performance
+
+- **Serial queue implications**: `withNodeQueue` serializes all native calls. Long-running calls (e.g. `syncWallet`) block all subsequent calls. New blocking calls must be documented and considered for cancellation support.
+- **`probeNodeReady` stall**: can stall up to 24 s on cold start (worst case). Callers must not call it from UI thread without a loading state.
+- **`postinstall` binary download pinning**: xcframework version is pinned. Any PR that bumps the version must verify the SHA-256 of the new artifact matches the download script's expectation.
+
 ## graphify
 
 This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.


### PR DESCRIPTION
## What

- Add Claude AI code review workflow (`.github/workflows/claude-code-review.yml`)
- Add Kimi AI code review workflow (`.github/workflows/kimi-code-review.yml`) with model `kimi-k3`
- Add `CLAUDE.md` — project context for AI reviewers (stack, build/test, conventions, review focus)
- Add `.kimi-config.yml` — points Kimi to read `CLAUDE.md` as primary context

## How to trigger

- Add label `ai-review/claude` or comment `@claude` on a PR → Claude reviews
- Add label `ai-review/kimi` or comment `@kimi` on a PR → Kimi reviews

## Required secrets

`ANTHROPIC_API_KEY` and `KIMI_API_KEY` must be set in repo Actions secrets.